### PR TITLE
Scalable 3D bracket meshing

### DIFF
--- a/examples/structural/example_6/example_6.cpp
+++ b/examples/structural/example_6/example_6.cpp
@@ -450,9 +450,14 @@ public:
         
         // initialize the design variable vector
         _c.ex_init.model->init_simp_dvs(_c.ex_init, *_dvs);
+        
+        // open the file where the history will be stored
+        _history.open("optim_history.txt", std::ostream::out);
     }
     
     virtual ~FunctionEvaluation() {
+        
+        _history.close();
         delete _dvs;
     }
     
@@ -710,12 +715,12 @@ public:
         writer.write_timestep(oss.str(), *_c.eq_sys, 1, (real_t)iter);
         
         // also, save the design iteration to a text file
-        MAST::Optimization::Utility::write_dv_to_file(*this,
-                                                      "optim_history.txt",
-                                                      iter,
-                                                      dvars,
-                                                      o,
-                                                      f);
+        MAST::Optimization::Utility::write_dhistory_to_file(*this,
+                                                            _history,
+                                                            iter,
+                                                            dvars,
+                                                            o,
+                                                            f);
 
     }
     
@@ -726,6 +731,7 @@ private:
     MAST::Optimization::DesignParameterVector<scalar_t> *_dvs;
     real_t                                               _volume;
     real_t                                               _vf;
+    std::ofstream                                        _history;
 };
 } // namespace Example6
 } // namespace Structural

--- a/examples/structural/example_6/example_6.cpp
+++ b/examples/structural/example_6/example_6.cpp
@@ -51,7 +51,6 @@
 #include <libmesh/mesh_generation.h>
 #include <libmesh/equation_systems.h>
 #include <libmesh/boundary_info.h>
-#include <libmesh/exodusII_io.h>
 #include <libmesh/nemesis_io.h>
 #include <libmesh/petsc_matrix.h>
 
@@ -100,18 +99,12 @@ public:
         model->init_analysis_dirichlet_conditions(*this);
         
         eq_sys->init();
-
-        //mesh->write("mesh.exo");
-        libMesh::Nemesis_IO(*mesh).write("mesh.exo");
-        
-        std::cout << "before rho_sys->reinit()" << std::endl;
-        Error(false, "");
         
         real_t
         filter_r = input("filter_radius",
                          "radius of geometric filter for level set field", 0.015);
         filter = new MAST::Mesh::libMeshWrapper::GeometricFilter(*rho_sys, filter_r);
-        rho_sys->reinit();
+        //rho_sys->reinit();
 
         // create and attach the null space to the matrix
         MAST::Physics::Elasticity::libMeshWrapper::NullSpace
@@ -450,29 +443,32 @@ public:
                        context_t           &c):
     _e_ops        (e_ops),
     _c            (c),
+    _dvs          (new MAST::Optimization::DesignParameterVector<scalar_t>(c.rho_sys->comm())),
     _volume       (_c.ex_init.model->reference_volume(_c.ex_init)),
     _vf           (_c.ex_init.input("volume_fraction",
                                     "upper limit for the volume fraction", 0.2)) {
         
         // initialize the design variable vector
-        _c.ex_init.model->init_simp_dvs(_c.ex_init, _dvs);
+        _c.ex_init.model->init_simp_dvs(_c.ex_init, *_dvs);
     }
     
-    virtual ~FunctionEvaluation() {}
+    virtual ~FunctionEvaluation() {
+        delete _dvs;
+    }
     
     
-    inline uint_t n_vars() const {return _dvs.size();}
+    inline uint_t n_vars() const {return _dvs->size();}
     inline uint_t   n_eq() const {return 0;}
     inline uint_t n_ineq() const {return 1;}
     virtual void init_dvar(std::vector<scalar_t>& x,
                            std::vector<scalar_t>& xmin,
                            std::vector<scalar_t>& xmax) {
 
-        Assert1(_dvs.size(), _dvs.size(), "Design variables must be initialized");
+        Assert1(_dvs->size(), _dvs->size(), "Design variables must be initialized");
         
-        x.resize(_dvs.size());
-        xmin.resize(_dvs.size());
-        xmax.resize(_dvs.size());
+        x.resize(_dvs->size(), 0.);
+        xmin.resize(_dvs->size());
+        xmax.resize(_dvs->size());
         
         std::fill(xmin.begin(), xmin.end(),      0.);
         std::fill(xmax.begin(), xmax.end(),    1.e0);
@@ -497,8 +493,10 @@ public:
         }
         else {
             
-            for (uint_t i=0; i<_dvs.size(); i++)
-                x[i] = _dvs[i]();
+            for (uint_t i=_dvs->local_begin(); i<_dvs->local_end(); i++)
+                x[i] = (*_dvs)[i]();
+            
+            _c.rho_sys->comm().sum(x);
         }
     }
     
@@ -513,8 +511,8 @@ public:
 
         std::cout << "New Evaluation" << std::endl;
         
-        Assert2(x.size() == _dvs.size(),
-                x.size(), _dvs.size(),
+        Assert2(x.size() == _dvs->size(),
+                x.size(), _dvs->size(),
                 "Incompatible design variable vector size.");
 
         libMesh::ExplicitSystem
@@ -536,9 +534,9 @@ public:
         // will be overwritten in \p rho_base.
         *rho_base = 1.;
         
-        for (uint_t i=0; i<_dvs.size(); i++) {
+        for (uint_t i=_dvs->local_begin(); i<_dvs->local_end(); i++) {
             
-            uint_t dof_id = _dvs.template get_parameter_for_dv<int>(i, "dof_id");
+            uint_t dof_id = _dvs->template get_parameter_for_dv<int>(i, "dof_id");
             
             if (dof_id >= first_local_rho && dof_id <  last_local_rho)
                 rho_base->set(dof_id, x[i]);
@@ -549,7 +547,7 @@ public:
         <scalar_t,
         typename TraitsType::assembled_vector_t,
         typename TraitsType::assembled_vector_t>
-        (_dvs, *rho_base, *_c.rho_sys->solution);
+        (*_dvs, *rho_base, *_c.rho_sys->solution);
         _c.rho_sys->solution->close();
         
         // this will copy the solution to libMesh::System::current_local_soluiton
@@ -608,7 +606,7 @@ public:
         _c.sys->update();
 
         {
-            libMesh::ExodusII_IO writer(*_c.mesh);
+            libMesh::Nemesis_IO writer(*_c.mesh);
             writer.write_timestep("solution.exo", *_c.eq_sys, 1, 1.);
         }
 
@@ -666,7 +664,7 @@ public:
                                      *_c.rho_sys->current_local_solution,  // filtered density
                                      *res,                                 // adjoint solution
                                      *_c.ex_init.filter,                   // geometric filter
-                                     _dvs,
+                                     *_dvs,
                                      obj_grad);
         }
         
@@ -684,7 +682,7 @@ public:
             volume.derivative(_c,
                               *_c.rho_sys->current_local_solution,
                               *_c.ex_init.filter,
-                              _dvs,
+                              *_dvs,
                               grads);
             for (uint_t i=0; i<grads.size(); i++)
                 grads[i] /= _volume;
@@ -708,7 +706,7 @@ private:
     
     ElemOps<TraitsType>                                 &_e_ops;
     context_t                                           &_c;
-    MAST::Optimization::DesignParameterVector<scalar_t>  _dvs;
+    MAST::Optimization::DesignParameterVector<scalar_t> *_dvs;
     real_t                                               _volume;
     real_t                                               _vf;
 };

--- a/include/mast/fe/eval/fe_derivative_evaluation.hpp
+++ b/include/mast/fe/eval/fe_derivative_evaluation.hpp
@@ -432,7 +432,7 @@ compute_hex_side_tangent_and_normal
  Eigen::Matrix<NodalScalarType, SpatialDim, Eigen::Dynamic>&               tangent,
  Eigen::Matrix<NodalScalarType, SpatialDim, Eigen::Dynamic>&               normal) {
     
-    Assert0(c.elem_is_quad(), "Element must be a quadrilateral");
+    Assert0(c.elem_is_hex(), "Element must be a hexagon");
 
     uint_t
     nq   = dx_dxi.cols(),

--- a/include/mast/mesh/generation/bracket2d.hpp
+++ b/include/mast/mesh/generation/bracket2d.hpp
@@ -333,13 +333,13 @@ struct Bracket2D {
         // all ranks will have DVs defined for all variables. So, we should be
         // operating on a replicated mesh
         //
-        Assert0(c.mesh->is_replicated(),
-                "Function currently assumes replicated mesh");
+        //Assert0(c.mesh->is_replicated(),
+        //        "Function currently assumes replicated mesh");
                 
         // iterate over all the element values
         libMesh::MeshBase::const_node_iterator
-        it  = c.mesh->nodes_begin(),
-        end = c.mesh->nodes_end();
+        it  = c.mesh->local_nodes_begin(),
+        end = c.mesh->local_nodes_end();
         
         //
         // maximum number of dvs is the number of nodes on the level set function
@@ -401,8 +401,8 @@ struct Bracket2D {
         // now, remove elements that are outside of the L-bracket domain
         //
         libMesh::MeshBase::element_iterator
-        e_it   = mesh.elements_begin(),
-        e_end  = mesh.elements_end();
+        e_it   = mesh.local_elements_begin(),
+        e_end  = mesh.local_elements_end();
         
         for ( ; e_it!=e_end; e_it++) {
             
@@ -433,8 +433,8 @@ struct Bracket2D {
         facing_right = false,
         facing_down  = false;
         
-        e_it   = mesh.elements_begin();
-        e_end  = mesh.elements_end();
+        e_it   = mesh.local_elements_begin();
+        e_end  = mesh.local_elements_end();
         
         for ( ; e_it != e_end; e_it++) {
             

--- a/include/mast/mesh/generation/bracket3d.hpp
+++ b/include/mast/mesh/generation/bracket3d.hpp
@@ -351,9 +351,9 @@ struct Bracket3D {
                        libMesh::UnstructuredMesh& mesh) {
         
         real_t
-        length  = c.input("length", "length of domain along x-axis", 1.),
-        height  = c.input("height", "length of domain along y-axis", 1.),
-        width   = c.input("width",  "length of domain along z-axis", 1.);
+        length  = c.input("length", "length of domain along x-axis", 0.3),
+        height  = c.input("height", "length of domain along y-axis", 0.3),
+        width   = c.input("width",  "length of domain along z-axis", 0.3);
         
         uint_t
         nx_divs = c.input("nx_divs", "number of elements along x-axis", 10),
@@ -497,6 +497,7 @@ struct Bracket3D {
             }
         }
         
+        dvs.synchronize();
         c.rho_sys->solution->close();
     }
 };

--- a/include/mast/mesh/generation/bracket3d.hpp
+++ b/include/mast/mesh/generation/bracket3d.hpp
@@ -90,6 +90,260 @@ struct Bracket3D {
     }
     
     
+    inline uint_t idx(const libMesh::ElemType type,
+                      const uint_t nx,
+                      const uint_t ny,
+                      const uint_t i,
+                      const uint_t j,
+                      const uint_t k)
+    {
+      switch(type)
+        {
+            case libMesh::HEX8:
+            {
+                return i + (nx+1)*(j + k*(ny+1));
+            }
+                
+            case libMesh::HEX27:
+            {
+                return i + (2*nx+1)*(j + k*(2*ny+1));
+            }
+                
+            default:
+                Error(false, "Invalid element type");
+        }
+
+      return libMesh::invalid_uint;
+    }
+
+    
+    inline void build_cube(libMesh::UnstructuredMesh & mesh,
+                           const uint_t nx,
+                           const uint_t ny,
+                           const uint_t nz,
+                           const real_t length,
+                           const real_t height,
+                           const real_t width,
+                           const libMesh::ElemType type) {
+        
+        Assert0(type == libMesh::HEX8 || type == libMesh::HEX27,
+                "Method only implemented for Hex8/Hex27");
+        
+        // Clear the mesh and start from scratch
+        mesh.clear();
+        
+        libMesh::BoundaryInfo & boundary_info = mesh.get_boundary_info();
+        
+        mesh.set_mesh_dimension(3);
+        mesh.set_spatial_dimension(3);
+        mesh.reserve_elem(nx*ny*nz);
+
+        if (type == libMesh::HEX8)
+            mesh.reserve_nodes( (nx+1)*(ny+1)*(nz+1) );
+        else if (type == libMesh::HEX27)
+            mesh.reserve_nodes( (2*nx+1)*(2*ny+1)*(2*nz+1) );
+
+        real_t
+        xmax    = length,
+        ymax    = height,
+        zmax    = width;
+        
+                
+
+        std::map<uint_t, libMesh::Node*> nodes;
+        
+        // Build the nodes.
+        uint_t
+        node_id = 0,
+        n       = 0;
+        switch (type)
+        {
+            case libMesh::HEX8: {
+
+                for (uint_t k=0; k<=nz; k++)
+                    for (uint_t j=0; j<=ny; j++)
+                        for (uint_t i=0; i<=nx; i++) {
+                            if ( i<=nx/10*4 || j>=ny/10*6) {
+                                nodes[node_id] =
+                                mesh.add_point(libMesh::Point(static_cast<real_t>(i)/static_cast<real_t>(nx)*length,
+                                                              static_cast<real_t>(j)/static_cast<real_t>(ny)*height,
+                                                              static_cast<real_t>(k)/static_cast<real_t>(nz)*width),
+                                               n++);
+                            }
+                            node_id++;
+                        }
+                
+                
+                break;
+            }
+
+            case libMesh::HEX27: {
+
+                for (uint_t k=0; k<=(2*nz); k++)
+                    for (uint_t j=0; j<=(2*ny); j++)
+                        for (uint_t i=0; i<=(2*nx); i++) {
+                            if ( i<=2*nx/10*4 || j>=2*ny/10*6) {
+                                nodes[node_id] =
+                                mesh.add_point(libMesh::Point(static_cast<real_t>(i)/static_cast<real_t>(2*nx)*length,
+                                                              static_cast<real_t>(j)/static_cast<real_t>(2*ny)*height,
+                                                              static_cast<real_t>(k)/static_cast<real_t>(2*nz)*width),
+                                               n++);
+                            }
+                            node_id++;
+                        }
+                
+                break;
+            }
+                
+                
+            default:
+                Assert0(false, "ERROR: Unrecognized 3D element type.");
+        }
+
+        // Build the elements.
+        uint_t
+        elem_id = 0;
+        switch (type)
+        {
+            case libMesh::HEX8:
+            {
+                for (uint_t k=0; k<nz; k++)
+                    for (uint_t j=0; j<ny; j++)
+                        for (uint_t i=0; i<nx; i++) {
+                            if (i < nx*4/10 || j>=ny*6/10) {
+                                
+                                libMesh::Elem
+                                *elem = mesh.add_elem(libMesh::Elem::build_with_id(libMesh::HEX8, elem_id++).release());
+                                elem->set_node(0) = nodes[idx(type,nx,ny,i,j,k)      ];
+                                elem->set_node(1) = nodes[idx(type,nx,ny,i+1,j,k)    ];
+                                elem->set_node(2) = nodes[idx(type,nx,ny,i+1,j+1,k)  ];
+                                elem->set_node(3) = nodes[idx(type,nx,ny,i,j+1,k)    ];
+                                elem->set_node(4) = nodes[idx(type,nx,ny,i,j,k+1)    ];
+                                elem->set_node(5) = nodes[idx(type,nx,ny,i+1,j,k+1)  ];
+                                elem->set_node(6) = nodes[idx(type,nx,ny,i+1,j+1,k+1)];
+                                elem->set_node(7) = nodes[idx(type,nx,ny,i,j+1,k+1)  ];
+                                
+                                if (k == 0)
+                                    boundary_info.add_side(elem, 0, 0);
+                                
+                                if (k == (nz-1))
+                                    boundary_info.add_side(elem, 5, 5);
+                                
+                                if (j == 0)
+                                    boundary_info.add_side(elem, 1, 1);
+                                
+                                if (j == (ny-1))
+                                    boundary_info.add_side(elem, 3, 3);
+                                
+                                if (i == 0)
+                                    boundary_info.add_side(elem, 4, 4);
+                                
+                                if (i == (nx-1))
+                                    boundary_info.add_side(elem, 2, 2);
+                                
+                                if (i==nx*3/10 && j<ny*6/10)
+                                    boundary_info.add_side(elem, 2, 6);
+                                
+                                if (j==ny*6/10 && i>nx*3/10)
+                                    boundary_info.add_side(elem, 1, 7);
+                            }
+                        }
+                break;
+            }
+                
+                
+            case libMesh::HEX27: {
+                
+                for (uint_t k=0; k<(2*nz); k += 2)
+                    for (uint_t j=0; j<(2*ny); j += 2)
+                        for (uint_t i=0; i<(2*nx); i += 2)
+                        {
+                            libMesh::Elem
+                            *elem = mesh.add_elem(libMesh::Elem::build_with_id(libMesh::HEX27, elem_id++).release());
+                            
+                            elem->set_node(0)  = nodes[idx(type,nx,ny,i,  j,  k)  ];
+                            elem->set_node(1)  = nodes[idx(type,nx,ny,i+2,j,  k)  ];
+                            elem->set_node(2)  = nodes[idx(type,nx,ny,i+2,j+2,k)  ];
+                            elem->set_node(3)  = nodes[idx(type,nx,ny,i,  j+2,k)  ];
+                            elem->set_node(4)  = nodes[idx(type,nx,ny,i,  j,  k+2)];
+                            elem->set_node(5)  = nodes[idx(type,nx,ny,i+2,j,  k+2)];
+                            elem->set_node(6)  = nodes[idx(type,nx,ny,i+2,j+2,k+2)];
+                            elem->set_node(7)  = nodes[idx(type,nx,ny,i,  j+2,k+2)];
+                            elem->set_node(8)  = nodes[idx(type,nx,ny,i+1,j,  k)  ];
+                            elem->set_node(9)  = nodes[idx(type,nx,ny,i+2,j+1,k)  ];
+                            elem->set_node(10) = nodes[idx(type,nx,ny,i+1,j+2,k)  ];
+                            elem->set_node(11) = nodes[idx(type,nx,ny,i,  j+1,k)  ];
+                            elem->set_node(12) = nodes[idx(type,nx,ny,i,  j,  k+1)];
+                            elem->set_node(13) = nodes[idx(type,nx,ny,i+2,j,  k+1)];
+                            elem->set_node(14) = nodes[idx(type,nx,ny,i+2,j+2,k+1)];
+                            elem->set_node(15) = nodes[idx(type,nx,ny,i,  j+2,k+1)];
+                            elem->set_node(16) = nodes[idx(type,nx,ny,i+1,j,  k+2)];
+                            elem->set_node(17) = nodes[idx(type,nx,ny,i+2,j+1,k+2)];
+                            elem->set_node(18) = nodes[idx(type,nx,ny,i+1,j+2,k+2)];
+                            elem->set_node(19) = nodes[idx(type,nx,ny,i,  j+1,k+2)];
+                            
+                            elem->set_node(20) = nodes[idx(type,nx,ny,i+1,j+1,k)  ];
+                            elem->set_node(21) = nodes[idx(type,nx,ny,i+1,j,  k+1)];
+                            elem->set_node(22) = nodes[idx(type,nx,ny,i+2,j+1,k+1)];
+                            elem->set_node(23) = nodes[idx(type,nx,ny,i+1,j+2,k+1)];
+                            elem->set_node(24) = nodes[idx(type,nx,ny,i,  j+1,k+1)];
+                            elem->set_node(25) = nodes[idx(type,nx,ny,i+1,j+1,k+2)];
+                            elem->set_node(26) = nodes[idx(type,nx,ny,i+1,j+1,k+1)];
+                            
+                            if (k == 0)
+                                boundary_info.add_side(elem, 0, 0);
+                            
+                            if (k == 2*(nz-1))
+                                boundary_info.add_side(elem, 5, 5);
+                            
+                            if (j == 0)
+                                boundary_info.add_side(elem, 1, 1);
+                            
+                            if (j == 2*(ny-1))
+                                boundary_info.add_side(elem, 3, 3);
+                            
+                            if (i == 0)
+                                boundary_info.add_side(elem, 4, 4);
+                            
+                            if (i == 2*(nx-1))
+                                boundary_info.add_side(elem, 2, 2);
+
+                            if (i==nx*4/10)
+                                boundary_info.add_side(elem, 2, 6);
+                            
+                            if (j==ny*6/10)
+                                boundary_info.add_side(elem, 1, 7);
+                        }
+                break;
+            }
+                
+            default:
+                Assert0(false, "ERROR: Unrecognized 3D element type.");
+        }
+        
+        // Add sideset names to boundary info (Z axis out of the screen)
+        boundary_info.sideset_name(0) = "back";
+        boundary_info.sideset_name(1) = "bottom";
+        boundary_info.sideset_name(2) = "right";
+        boundary_info.sideset_name(3) = "top";
+        boundary_info.sideset_name(4) = "left";
+        boundary_info.sideset_name(5) = "front";
+        boundary_info.sideset_name(6) = "facing_right";
+        boundary_info.sideset_name(7) = "facing_down";
+
+        // Add nodeset names to boundary info
+        boundary_info.nodeset_name(0) = "back";
+        boundary_info.nodeset_name(1) = "bottom";
+        boundary_info.nodeset_name(2) = "right";
+        boundary_info.nodeset_name(3) = "top";
+        boundary_info.nodeset_name(4) = "left";
+        boundary_info.nodeset_name(5) = "front";
+
+        // Done building the mesh.  Now prepare it for use.
+        mesh.prepare_for_use ();
+    }
+
+    
     
     template <typename Context>
     inline void
@@ -97,16 +351,17 @@ struct Bracket3D {
                        libMesh::UnstructuredMesh& mesh) {
         
         real_t
-        length  = c.input("length", "length of domain along x-axis", 0.3),
-        height  = c.input("height", "length of domain along y-axis", 0.3),
-        width   = c.input("width",  "length of domain along z-axis", 0.3);
+        length  = c.input("length", "length of domain along x-axis", 1.),
+        height  = c.input("height", "length of domain along y-axis", 1.),
+        width   = c.input("width",  "length of domain along z-axis", 1.);
         
         uint_t
-        nx_divs = c.input("nx_divs", "number of elements along x-axis", 20),
-        ny_divs = c.input("ny_divs", "number of elements along y-axis", 20),
-        nz_divs = c.input("nz_divs", "number of elements along z-axis", 20);
+        nx_divs = c.input("nx_divs", "number of elements along x-axis", 10),
+        ny_divs = c.input("ny_divs", "number of elements along y-axis", 10),
+        nz_divs = c.input("nz_divs", "number of elements along z-axis", 10);
         
-        if (nx_divs%10 != 0 || ny_divs%10 != 0) libmesh_error();
+        if (nx_divs%10 != 0 || ny_divs%10 != 0)
+            Error(false, "number of divisions in x and y must be multiples of 10");
         
         std::string
         t = c.input("elem_type", "type of geometric element in the mesh", "hex8");
@@ -126,14 +381,12 @@ struct Bracket3D {
         //
         // initialize the mesh with one element
         //
-        libMesh::MeshTools::Generation::build_cube(mesh,
-                                                   nx_divs, ny_divs, nz_divs,
-                                                   0, length,
-                                                   0, height,
-                                                   0, width,
-                                                   e_type);
-        
-        _delete_elems_from_bracket_mesh(c, mesh);
+        build_cube(mesh,
+                   nx_divs, ny_divs, nz_divs,
+                   length,
+                   height,
+                   width,
+                   e_type);
     }
     
         
@@ -203,13 +456,13 @@ struct Bracket3D {
         // all ranks will have DVs defined for all variables. So, we should be
         // operating on a replicated mesh
         //
-        Assert0(c.mesh->is_replicated(),
-                "Function currently assumes replicated mesh");
+        //Assert0(c.mesh->is_replicated(),
+        //        "Function currently assumes replicated mesh");
                 
         // iterate over all the element values
         libMesh::MeshBase::const_node_iterator
-        it  = c.mesh->nodes_begin(),
-        end = c.mesh->nodes_end();
+        it  = c.mesh->local_nodes_begin(),
+        end = c.mesh->local_nodes_end();
         
         //
         // maximum number of dvs is the number of nodes on the level set function
@@ -245,101 +498,6 @@ struct Bracket3D {
         }
         
         c.rho_sys->solution->close();
-    }
-    
-    
-    
-    template <typename Context>
-    inline void
-    _delete_elems_from_bracket_mesh(Context& c,
-                                    libMesh::MeshBase &mesh) {
-        
-        real_t
-        tol     = 1.e-12,
-        x       = -1.,
-        y       = -1.,
-        l_frac  = 0.4,
-        w_frac  = 0.4,
-        length  = c.input("length", "length of domain along x-axis", 0.3),
-        height  = c.input("height", "length of domain along y-axis", 0.3),
-        x_lim   = length * l_frac,
-        y_lim   = height * (1.-w_frac);
-        
-        //
-        // now, remove elements that are outside of the L-bracket domain
-        //
-        libMesh::MeshBase::element_iterator
-        e_it   = mesh.elements_begin(),
-        e_end  = mesh.elements_end();
-        
-        for ( ; e_it!=e_end; e_it++) {
-            
-            libMesh::Elem* elem = *e_it;
-            x = length;
-            y = 0.;
-            for (uint_t i=0; i<elem->n_nodes(); i++) {
-                const libMesh::Node& n = elem->node_ref(i);
-                if (x > n(0)) x = n(0);
-                if (y < n(1)) y = n(1);
-            }
-            
-            //
-            // delete element if the lowest x,y locations are outside of the bracket
-            // domain
-            //
-            if (x >= x_lim && y<= y_lim)
-                mesh.delete_elem(elem);
-        }
-        
-        mesh.prepare_for_use();
-        
-        //
-        // add the two additional boundaries to the boundary info so that
-        // we can apply loads on them
-        //
-        bool
-        facing_right = false,
-        facing_down  = false;
-        
-        e_it   = mesh.elements_begin();
-        e_end  = mesh.elements_end();
-        
-        for ( ; e_it != e_end; e_it++) {
-            
-            libMesh::Elem* elem = *e_it;
-            
-            if (!elem->on_boundary()) continue;
-            
-            for (uint_t i=0; i<elem->n_sides(); i++) {
-                
-                if (elem->neighbor_ptr(i)) continue;
-                
-                std::unique_ptr<libMesh::Elem> s(elem->side_ptr(i).release());
-                
-                const libMesh::Point p = s->centroid();
-                
-                facing_right = true;
-                facing_down  = true;
-                for (uint_t j=0; j<s->n_nodes(); j++) {
-                    const libMesh::Node& n = s->node_ref(j);
-                    
-                    if (n(0) < x_lim ||  n(1) > y_lim) {
-                        facing_right = false;
-                        facing_down  = false;
-                    }
-                    else if (std::fabs(n(0) - p(0)) > tol)
-                        facing_right = false;
-                    else if (std::fabs(n(1) - p(1)) > tol)
-                        facing_down = false;
-                }
-                
-                if (facing_right) mesh.boundary_info->add_side(elem, i, 6);
-                if (facing_down) mesh.boundary_info->add_side(elem, i, 7);
-            }
-        }
-        
-        mesh.boundary_info->sideset_name(6) = "facing_right";
-        mesh.boundary_info->sideset_name(7) = "facing_down";
     }
 };
 

--- a/include/mast/mesh/generation/bracket3d.hpp
+++ b/include/mast/mesh/generation/bracket3d.hpp
@@ -452,13 +452,6 @@ struct Bracket3D {
         real_t
         val     = 0.;
         
-        //
-        // all ranks will have DVs defined for all variables. So, we should be
-        // operating on a replicated mesh
-        //
-        //Assert0(c.mesh->is_replicated(),
-        //        "Function currently assumes replicated mesh");
-                
         // iterate over all the element values
         libMesh::MeshBase::const_node_iterator
         it  = c.mesh->local_nodes_begin(),
@@ -468,13 +461,12 @@ struct Bracket3D {
         // maximum number of dvs is the number of nodes on the level set function
         // mesh. We will evaluate the actual number of dvs
         //
-        //dvs.reserve(c.mesh->n_elem());
 
         for ( ; it!=end; it++) {
             
             const libMesh::Node& n = **it;
             
-            dof_id                     = n.dof_number(sys_num, 0, 0);
+            dof_id = n.dof_number(sys_num, 0, 0);
             
             if ((n(1)-filter_radius) <= y_lim &&
                 (n(0)+filter_radius) >= length*(1.-frac)) {

--- a/include/mast/mesh/generation/bracket3d.hpp
+++ b/include/mast/mesh/generation/bracket3d.hpp
@@ -213,7 +213,8 @@ struct Bracket3D {
                             if (i < nx*4/10 || j>=ny*6/10) {
                                 
                                 libMesh::Elem
-                                *elem = mesh.add_elem(libMesh::Elem::build_with_id(libMesh::HEX8, elem_id++).release());
+                                *elem = mesh.add_elem(libMesh::Elem::build(libMesh::HEX8).release());
+                                elem->set_id(elem_id++);
                                 elem->set_node(0) = nodes[idx(type,nx,ny,i,j,k)      ];
                                 elem->set_node(1) = nodes[idx(type,nx,ny,i+1,j,k)    ];
                                 elem->set_node(2) = nodes[idx(type,nx,ny,i+1,j+1,k)  ];

--- a/include/mast/mesh/generation/bracket3d.hpp
+++ b/include/mast/mesh/generation/bracket3d.hpp
@@ -260,7 +260,8 @@ struct Bracket3D {
                         for (uint_t i=0; i<(2*nx); i += 2)
                         {
                             libMesh::Elem
-                            *elem = mesh.add_elem(libMesh::Elem::build_with_id(libMesh::HEX27, elem_id++).release());
+                            *elem = mesh.add_elem(libMesh::Elem::build(libMesh::HEX27).release());
+                            elem->set_id(elem_id++);
                             
                             elem->set_node(0)  = nodes[idx(type,nx,ny,i,  j,  k)  ];
                             elem->set_node(1)  = nodes[idx(type,nx,ny,i+2,j,  k)  ];

--- a/include/mast/mesh/libmesh/geometric_filter.hpp
+++ b/include/mast/mesh/libmesh/geometric_filter.hpp
@@ -368,12 +368,13 @@ public:
             
             for ( ; vec_it != vec_end; vec_it++) {
                 
-                if (dvs.is_design_parameter(map_it->first))
+                if (dvs.is_design_parameter_index(map_it->first))
                     o
                     << " : " << std::setw(8) << vec_it->first
                     << " (" << std::setw(8) << vec_it->second << " )";
                 else
-                    std::cout << " : " << map_it->first;
+                    std::cout
+                    << " : " << std::setw(8) << map_it->first;
             }
             std::cout << std::endl;
         }
@@ -518,7 +519,7 @@ private:
                 
                 std::vector<std::pair<size_t, real_t>>
                 indices_dists;
-                indices_dists.push_back(std::pair<size_t, real_t>(dof_1, 0.));
+                indices_dists.push_back(std::pair<size_t, real_t>(node->id(), 0.));
                 /*nanoflann::RadiusResultSet<real_t, size_t>
                 resultSet(_radius*_radius, indices_dists);
                 

--- a/include/mast/optimization/topology/simp/libmesh/assemble_output_sensitivity.hpp
+++ b/include/mast/optimization/topology/simp/libmesh/assemble_output_sensitivity.hpp
@@ -120,7 +120,7 @@ public:
         param_dof_ids(dvs.size());
         
         // cache values for later use
-        for (uint_t i=0; i<dvs.size(); i++)
+        for (uint_t i=dvs.local_begin(); i<dvs.local_end(); i++)
             param_dof_ids[i] = dvs.get_data_for_parameter(dvs[i]).template get<int>("dof_id");
         
         std::set<uint_t> density_dofs;
@@ -145,7 +145,7 @@ public:
             
             dres_e.setZero(sol_accessor.n_dofs());
 
-            for (uint_t i=0; i<dvs.size(); i++) {
+            for (uint_t i=dvs.local_begin(); i<dvs.local_end(); i++) {
                 
                 // this assumes that if the DV (which is associated with a node)
                 // is connected to this element, then the dof_indices for this

--- a/include/mast/optimization/topology/simp/libmesh/volume.hpp
+++ b/include/mast/optimization/topology/simp/libmesh/volume.hpp
@@ -121,7 +121,7 @@ public:
         param_dof_ids(dvs.size());
         
         // cache values for later use
-        for (uint_t i=0; i<dvs.size(); i++)
+        for (uint_t i=dvs.local_begin(); i<dvs.local_end(); i++)
             param_dof_ids[i] = dvs.get_data_for_parameter(dvs[i]).template get<int>("dof_id");
         
         std::set<uint_t> density_dofs;
@@ -141,7 +141,7 @@ public:
             density_accessor.init(*c.elem);
             density_accessor.init_dof_id_set(density_dofs);
 
-            for (uint_t i=0; i<dvs.size(); i++) {
+            for (uint_t i=dvs.local_begin(); i<dvs.local_end(); i++) {
                 
                 // this assumes that if the DV (which is associated with a node)
                 // is connected to this element, then the dof_indices for this

--- a/include/mast/optimization/utility/design_history.hpp
+++ b/include/mast/optimization/utility/design_history.hpp
@@ -35,18 +35,64 @@ namespace MAST {
 namespace Optimization {
 namespace Utility {
 
-inline void write_dv_to_file(const std::string     &file,
-                             const uint_t           iter,
-                             std::vector<real_t>  &dv) {
+template <typename FuncEvalType>
+inline void write_dv_to_file(const FuncEvalType          &feval,
+                             const std::string           &file,
+                             const uint_t                 iter,
+                             const std::vector<real_t>   &x,
+                             const real_t                &obj,
+                             const std::vector<real_t>   &fval) {
     
+    std::ofstream output;
+
+    // create a new file for first iteration. Otherwise append
+    if (iter == 0)
+        output.open(file.c_str(), std::ofstream::out);
+    else
+        output.open(file.c_str(), std::ofstream::app);
+    
+    // write header for the first iteration
+    if (iter == 0) {
+
+        // number of desing variables
+        output
+        << std::setw(10) << "n_dv" << std::setw(10) << feval.n_vars() << std::endl;
+        output
+        << std::setw(10) << "n_eq" << std::setw(10) << feval.n_eq() << std::endl;
+        output
+        << std::setw(10) << "n_ineq" << std::setw(10) << feval.n_ineq() << std::endl;
+
+        output << std::setw(10) << "Iter";
+        for (unsigned int i=0; i < x.size(); i++) {
+            std::stringstream x; x << "x_" << i;
+            output << std::setw(20) << x.str();
+        }
+        output << std::setw(20) << "Obj";
+        for (unsigned int i=0; i<fval.size(); i++) {
+            std::stringstream f; f << "f_" << i;
+            output << std::setw(20) << f.str();
+        }
+        output << std::endl;
+    }
+    
+    output << std::setw(10) << iter;
+    for (unsigned int i=0; i < x.size(); i++)
+        output << std::setw(20) << x[i];
+    output << std::setw(20) << obj;
+    for (unsigned int i=0; i < fval.size(); i++)
+        output << std::setw(20) << fval[i];
+    output << std::endl;
+    
+    
+    output.close();
 }
 
 
-template <typename FuncEvalType, typename ScalarType>
+template <typename FuncEvalType>
 inline void initialize_dv_from_output_file(const FuncEvalType      &f_eval,
                                            const std::string       &file,
                                            const uint_t             iter,
-                                           std::vector<ScalarType> &dv) {
+                                           std::vector<real_t>     &dv) {
     
     
     struct stat stat_info;
@@ -126,9 +172,55 @@ inline void initialize_dv_from_output_file(const FuncEvalType      &f_eval,
     
     // make sure that the file has data
     for (unsigned int i=0; i<ndv; i++)
-        dv[i] = ScalarType(stod(results[i+1]));
+        dv[i] = real_t(stod(results[i+1]));
 }
 
+
+
+template <typename FuncEvalType>
+inline void write_dv_to_file(const FuncEvalType            &feval,
+                             const std::string             &file,
+                             const uint_t                   iter,
+                             const std::vector<complex_t>  &x,
+                             const complex_t               &obj,
+                             const std::vector<complex_t>  &fval) {
+    
+    Error(false, "Not implemented for complex type");
+}
+
+
+template <typename FuncEvalType>
+inline void initialize_dv_from_output_file(const FuncEvalType      &f_eval,
+                                           const std::string       &file,
+                                           const uint_t             iter,
+                                           std::vector<complex_t>  &dv) {
+
+    Error(false, "Not implemented for complex type");
+}
+
+
+#if MAST_ENABLE_ADOLC == 1
+template <typename FuncEvalType>
+inline void write_dv_to_file(const FuncEvalType               &feval,
+                             const std::string                &file,
+                             const uint_t                      iter,
+                             const std::vector<adouble_tl_t>  &x,
+                             const adouble_tl_t               &obj,
+                             const std::vector<adouble_tl_t>  &fval) {
+    
+    Error(false, "Not implemented for adouble type");
+}
+
+
+template <typename FuncEvalType>
+inline void initialize_dv_from_output_file(const FuncEvalType         &f_eval,
+                                           const std::string          &file,
+                                           const uint_t                iter,
+                                           std::vector<adouble_tl_t>  &dv) {
+    
+    Error(false, "Not implemented for adouble type");
+}
+#endif
 
 } // namespace Utility
 } // namespace Optimization


### PR DESCRIPTION
Modified the meshing algorithm for 3D bracket model for scalable computation.

The previous approach was deleting the elements from a mesh generated with build_cube leading to very large computational cost of multiple calls to prepare_for_use. This now implements the mesh generation directly in the model generation file.