### PR TITLE
Use mesh refinement for creating larger 3D mesh

### DIFF
--- a/examples/structural/example_6/example_6.cpp
+++ b/examples/structural/example_6/example_6.cpp
@@ -731,7 +731,7 @@ int main(int argc, char** argv) {
     libMesh::LibMeshInit init(argc, argv);
     MAST::Utility::GetPotWrapper input(argc, argv);
     
-    using model_t     = MAST::Mesh::Generation::Bracket2D;
+    using model_t     = MAST::Mesh::Generation::Bracket3D;
     
     using traits_t    = MAST::Examples::Structural::Example6::Traits<real_t, real_t, real_t, model_t>;
     using elem_ops_t  = MAST::Examples::Structural::Example6::ElemOps<traits_t>;

--- a/include/mast/mesh/generation/bracket3d.hpp
+++ b/include/mast/mesh/generation/bracket3d.hpp
@@ -37,7 +37,8 @@
 #include <libmesh/boundary_info.h>
 #include <libmesh/dirichlet_boundaries.h>
 #include <libmesh/zero_function.h>
-
+#include <libmesh/mesh_refinement.h>
+#include <libmesh/mesh_modification.h>
 
 
 namespace MAST {
@@ -363,7 +364,8 @@ struct Bracket3D {
         uint_t
         nx_divs = c.input("nx_divs", "number of elements along x-axis", 10),
         ny_divs = c.input("ny_divs", "number of elements along y-axis", 10),
-        nz_divs = c.input("nz_divs", "number of elements along z-axis", 10);
+        nz_divs = c.input("nz_divs", "number of elements along z-axis", 10),
+        n_refine= c.input("n_uniform_refinement", "number of times the mesh is uniformly refined", 0);
         
         if (nx_divs%10 != 0 || ny_divs%10 != 0)
             Error(false, "number of divisions in x and y must be multiples of 10");
@@ -392,6 +394,13 @@ struct Bracket3D {
                    height,
                    width,
                    e_type);
+        
+        // we now uniformly refine this mesh
+        if (n_refine) {
+            
+            libMesh::MeshRefinement(mesh).uniformly_refine(n_refine);
+            libMesh::MeshTools::Modification::flatten(mesh);
+        }
     }
     
         


### PR DESCRIPTION
Following discussion [here](https://github.com/libMesh/libmesh/issues/2706), bracket 3D mesh generation can optionally use mesh refinement to create a larger mesh for optimization.