### PR TITLE
Geometric filter mpi fix

### DIFF
--- a/examples/structural/example_5/example_5.cpp
+++ b/examples/structural/example_5/example_5.cpp
@@ -575,10 +575,9 @@ public:
         }
 
         _c.ex_init.filter->template compute_filtered_values
-        <scalar_t,
-        typename TraitsType::assembled_vector_t,
-        typename TraitsType::assembled_vector_t>
-        (*_dvs, rho_base, rho_filtered);
+        <typename TraitsType::assembled_vector_t,
+         typename TraitsType::assembled_vector_t>
+        (rho_base, rho_filtered);
         
         //////////////////////////////////////////////////////////////////////
         // check to see if the sensitivity of constraint is requested

--- a/examples/structural/example_6/example_6.cpp
+++ b/examples/structural/example_6/example_6.cpp
@@ -599,11 +599,9 @@ public:
                           x[i]);
         rho_base->close();
         
-        _c.ex_init.filter->template compute_filtered_values
-        <scalar_t,
-        typename TraitsType::assembled_vector_t,
-        typename TraitsType::assembled_vector_t>
-        (*_dvs, *rho_base, *_c.rho_sys->solution);
+        _c.ex_init.filter->compute_filtered_values
+        (dynamic_cast<libMesh::PetscVector<scalar_t>*>(rho_base.get())->vec(),
+         dynamic_cast<libMesh::PetscVector<scalar_t>*>(_c.rho_sys->solution.get())->vec());
         _c.rho_sys->solution->close();
         
         // this will copy the solution to libMesh::System::current_local_soluiton
@@ -650,7 +648,7 @@ public:
         
         MAST::Solvers::PETScWrapper::LinearSolver
         linear_solver(_c.eq_sys->comm().get());
-        linear_solver.init(m);
+        linear_solver.init(m, &_c.sys->name());
         linear_solver.solve(sol, b);
 
         _c.sys->update();

--- a/include/mast/mesh/generation/bracket2d.hpp
+++ b/include/mast/mesh/generation/bracket2d.hpp
@@ -516,14 +516,8 @@ struct Bracket2D {
         
         real_t
         tol           = 1.e-12,
-        l_frac        = 0.4,
-        h_frac        = 0.4,
         length        = c.input("length", "length of domain along x-axis", 0.3),
         height        = c.input("height", "length of domain along y-axis", 0.3),
-        x_lim         = length * l_frac,
-        y_lim         = height * (1.-h_frac),
-        frac          = c.input("loadlength_fraction", "fraction of boundary length on which pressure will act", 0.125),
-        filter_radius = c.input("filter_radius", "radius of geometric filter for level set field", 0.015),
         rho_min       = c.input("rho_min", "lower limit on density variable", 0.),
         vf            = c.input("volume_fraction",
                                 "upper limit for the volume fraction", 0.2);

--- a/include/mast/mesh/generation/bracket3d.hpp
+++ b/include/mast/mesh/generation/bracket3d.hpp
@@ -448,14 +448,6 @@ struct Bracket3D {
         
         real_t
         tol           = 1.e-12,
-        l_frac        = 0.4,
-        h_frac        = 0.4,
-        length        = c.input("length", "length of domain along x-axis", 0.3),
-        height        = c.input("height", "length of domain along y-axis", 0.3),
-        x_lim         = length * l_frac,
-        y_lim         = height * (1.-h_frac),
-        frac          = c.input("loadlength_fraction", "fraction of boundary length on which pressure will act", 0.125),
-        filter_radius = c.input("filter_radius", "radius of geometric filter for level set field", 0.015),
         rho_min       = c.input("rho_min", "lower limit on density variable", 0.),
         vf            = c.input("volume_fraction", "upper limit for the volume fraction", 0.2);
         

--- a/include/mast/mesh/generation/bracket3d.hpp
+++ b/include/mast/mesh/generation/bracket3d.hpp
@@ -85,7 +85,7 @@ struct Bracket3D {
         real_t
         length  = c.input("length", "length of domain along x-axis", 0.3),
         height  = c.input("height", "length of domain along y-axis", 0.3),
-        width   = c.input("width",  "length of domain along z-axis", 0.1);
+        width   = c.input("width",  "length of domain along z-axis", 0.06);
         
         return length * height * width;
     }
@@ -359,12 +359,12 @@ struct Bracket3D {
         real_t
         length  = c.input("length", "length of domain along x-axis", 0.3),
         height  = c.input("height", "length of domain along y-axis", 0.3),
-        width   = c.input("width",  "length of domain along z-axis", 0.1);
+        width   = c.input("width",  "length of domain along z-axis", 0.06);
         
         uint_t
         nx_divs = c.input("nx_divs", "number of elements along x-axis", 10),
         ny_divs = c.input("ny_divs", "number of elements along y-axis", 10),
-        nz_divs = c.input("nz_divs", "number of elements along z-axis", 4),
+        nz_divs = c.input("nz_divs", "number of elements along z-axis", 2),
         n_refine= c.input("n_uniform_refinement", "number of times the mesh is uniformly refined", 0);
         
         if (nx_divs%10 != 0 || ny_divs%10 != 0)

--- a/include/mast/mesh/libmesh/geometric_filter.hpp
+++ b/include/mast/mesh/libmesh/geometric_filter.hpp
@@ -34,7 +34,7 @@
 #include "libmesh/node.h"
 #include "libmesh/elem.h"
 #include "libmesh/mesh_base.h"
-#include "libmesh/numeric_vector.h"
+#include "libmesh/petsc_vector.h"
 #ifdef LIBMESH_HAVE_NANOFLANN
 #include "libmesh/nanoflann.hpp"
 #endif
@@ -88,17 +88,162 @@ public:
     virtual ~GeometricFilter() {
         
         if (_augment_send_list) delete _augment_send_list;
+        
+        // delete the matrix
+        MatDestroy(&_weight_matrix);
     }
     
-    /*!
-     *   computes the filtered output from the provided input.
-     */
+//    /*!
+//     *   computes the filtered output from the provided input.
+//     */
+//    inline void
+//    compute_filtered_values
+//    (const MAST::Optimization::DesignParameterVector<real_t> &dvs,
+//     const libMesh::NumericVector<real_t>            &input,
+//     libMesh::NumericVector<real_t>                  &output,
+//     bool                                            close_vec) const {
+//
+//        Assert2(input.size() == _system.n_dofs(),
+//                input.size(), _system.n_dofs(),
+//                "Incompatible vector sizes");
+//        Assert2(output.size() == _system.n_dofs(),
+//                output.size(), _system.n_dofs(),
+//                "Incompatible vector sizes");
+//
+//        output.zero();
+//
+//        std::vector<real_t> input_vals(input.size(), 0.);
+//        input.localize(input_vals);
+//
+//        const uint_t
+//        first_local_dof = _system.get_dof_map().first_dof(_system.comm().rank()),
+//        last_local_dof  = _system.get_dof_map().end_dof(_system.comm().rank());
+//
+//        std::map<uint_t, std::vector<std::pair<uint_t, real_t>>>::const_iterator
+//        map_it   = _filter_map.begin(),
+//        map_end  = _filter_map.end();
+//
+//        for ( ; map_it != map_end; map_it++) {
+//
+//            if (map_it->first >= first_local_dof &&
+//                map_it->first <  last_local_dof) {
+//
+//                std::vector<std::pair<uint_t, real_t>>::const_iterator
+//                vec_it  = map_it->second.begin(),
+//                vec_end = map_it->second.end();
+//
+//                for ( ; vec_it != vec_end; vec_it++) {
+//                    if (map_it->first >= input.first_local_index() &&
+//                        map_it->first <  input.last_local_index()) {
+//
+//                        if (dvs.is_design_parameter_index(map_it->first))
+//                            output.add(map_it->first, input_vals[vec_it->first] * vec_it->second);
+//                        else
+//                            output.set(map_it->first, input_vals[map_it->first]);
+//                    }
+//                }
+//            }
+//        }
+//
+//        if (close_vec)
+//            output.close();
+//    }
+    
+//    /*!
+//     *  for large problems it is more efficient to specify only the non-zero entries in the input vector in
+//     *  \p nonzero_vals. Here, \p output is expected to be of type SERIAL vector. All ranks in the
+//     *  communicator will perform the same operaitons and provide an identical \p output vector.
+//     *  If \p close_vector is \p true then \p output.close() will be called in this
+//     *  routines, otherwise not.
+//     */
+//    template <typename ScalarType, typename VecType>
+//    inline void
+//    compute_filtered_values
+//    (const MAST::Optimization::DesignParameterVector<ScalarType> &dvs,
+//     const std::map<uint_t, ScalarType>              &nonzero_vals,
+//     VecType                                         &output) const {
+//
+//        Assert2(output.size() == _system.n_dofs(),
+//                output.size(), _system.n_dofs(),
+//                "Incompatible vector sizes");
+//        Assert2(output.type() == libMesh::SERIAL,
+//                output.type(), libMesh::SERIAL,
+//                "Incompatible vector");
+//
+//        MAST::Numerics::Utility::setZero(output);
+//
+//        const uint_t
+//        first_local_dof = _system.get_dof_map().first_dof(_system.comm().rank()),
+//        last_local_dof  = _system.get_dof_map().end_dof(_system.comm().rank());
+//
+//        std::map<uint_t, std::vector<std::pair<uint_t, real_t>>>::const_iterator
+//        map_it   = _filter_map.begin(),
+//        map_end  = _filter_map.end();
+//
+//        for ( ; map_it != map_end; map_it++) {
+//
+//            if (map_it->first >= first_local_dof &&
+//                map_it->first <  last_local_dof) {
+//
+//                std::vector<std::pair<uint_t, real_t>>::const_iterator
+//                vec_it  = map_it->second.begin(),
+//                vec_end = map_it->second.end();
+//
+//                for ( ; vec_it != vec_end; vec_it++) {
+//                    if (nonzero_vals.count(vec_it->first)) {
+//
+//                        if (dvs.is_design_parameter(map_it->first))
+//                            MAST::Numerics::Utility::add
+//                            (output, map_it->first, nonzero_vals[vec_it->first] * vec_it->second);
+//                        else
+//                            MAST::Numerics::Utility::set
+//                            (output, map_it->first, nonzero_vals[map_it->first]);
+//                    }
+//                }
+//            }
+//        }
+//    }
+    
+    
     inline void
-    compute_filtered_values
-    (const MAST::Optimization::DesignParameterVector<real_t> &dvs,
-     const libMesh::NumericVector<real_t>            &input,
-     libMesh::NumericVector<real_t>                  &output,
-     bool                                            close_vec) const {
+    compute_filtered_values(Vec       input,
+                            Vec       output) const {
+        
+//        Assert2(input.size() == _system.n_dofs(),
+//                input.size(), _system.n_dofs(),
+//                "Incompatible vector sizes");
+//        Assert2(output.size() == _system.n_dofs(),
+//                output.size(), _system.n_dofs(),
+//                "Incompatible vector sizes");
+        
+        //MAST::Numerics::Utility::setZero(output);
+        
+        MatMult(_weight_matrix, input, output);
+    }
+    
+    inline void
+    compute_filtered_values(libMesh::NumericVector<real_t>  &input,
+                            libMesh::NumericVector<real_t>  &output) const {
+        
+//        Assert2(input.size() == _system.n_dofs(),
+//                input.size(), _system.n_dofs(),
+//                "Incompatible vector sizes");
+//        Assert2(output.size() == _system.n_dofs(),
+//                output.size(), _system.n_dofs(),
+//                "Incompatible vector sizes");
+        
+        //MAST::Numerics::Utility::setZero(output);
+        
+        this->compute_filtered_values
+        (dynamic_cast<libMesh::PetscVector<real_t>&>(input).vec(),
+         dynamic_cast<libMesh::PetscVector<real_t>&>(output).vec());
+    }
+
+
+    template <typename ScalarType>
+    inline void
+    compute_filtered_values(Eigen::Matrix<ScalarType, Eigen::Dynamic, 1>  &input,
+                            Eigen::Matrix<ScalarType, Eigen::Dynamic, 1>  &output) const {
         
         Assert2(input.size() == _system.n_dofs(),
                 input.size(), _system.n_dofs(),
@@ -106,203 +251,51 @@ public:
         Assert2(output.size() == _system.n_dofs(),
                 output.size(), _system.n_dofs(),
                 "Incompatible vector sizes");
-        
-        output.zero();
-        
-        std::vector<real_t> input_vals(input.size(), 0.);
-        input.localize(input_vals);
-
-        const uint_t
-        first_local_dof = _system.get_dof_map().first_dof(_system.comm().rank()),
-        last_local_dof  = _system.get_dof_map().end_dof(_system.comm().rank());
-
-        std::map<uint_t, std::vector<std::pair<uint_t, real_t>>>::const_iterator
-        map_it   = _filter_map.begin(),
-        map_end  = _filter_map.end();
-        
-        for ( ; map_it != map_end; map_it++) {
-            
-            if (map_it->first >= first_local_dof &&
-                map_it->first <  last_local_dof) {
-                
-                std::vector<std::pair<uint_t, real_t>>::const_iterator
-                vec_it  = map_it->second.begin(),
-                vec_end = map_it->second.end();
-                
-                for ( ; vec_it != vec_end; vec_it++) {
-                    if (map_it->first >= input.first_local_index() &&
-                        map_it->first <  input.last_local_index()) {
-                        
-                        if (dvs.is_design_parameter_index(map_it->first))
-                            output.add(map_it->first, input_vals[vec_it->first] * vec_it->second);
-                        else
-                            output.set(map_it->first, input_vals[map_it->first]);
-                    }
-                }
-            }
-        }
-        
-        if (close_vec)
-            output.close();
-    }
-    
-    /*!
-     *  for large problems it is more efficient to specify only the non-zero entries in the input vector in
-     *  \p nonzero_vals. Here, \p output is expected to be of type SERIAL vector. All ranks in the
-     *  communicator will perform the same operaitons and provide an identical \p output vector.
-     *  If \p close_vector is \p true then \p output.close() will be called in this
-     *  routines, otherwise not.
-     */
-    template <typename ScalarType, typename VecType>
-    inline void
-    compute_filtered_values
-    (const MAST::Optimization::DesignParameterVector<ScalarType> &dvs,
-     const std::map<uint_t, ScalarType>              &nonzero_vals,
-     VecType                                         &output) const {
-        
-        Assert2(output.size() == _system.n_dofs(),
-                output.size(), _system.n_dofs(),
-                "Incompatible vector sizes");
-        Assert2(output.type() == libMesh::SERIAL,
-                output.type(), libMesh::SERIAL,
-                "Incompatible vector");
+        Assert0(_system.comm().size() == 1, "Method only applicable for serial runs");
         
         MAST::Numerics::Utility::setZero(output);
         
-        const uint_t
-        first_local_dof = _system.get_dof_map().first_dof(_system.comm().rank()),
-        last_local_dof  = _system.get_dof_map().end_dof(_system.comm().rank());
-
-        std::map<uint_t, std::vector<std::pair<uint_t, real_t>>>::const_iterator
-        map_it   = _filter_map.begin(),
-        map_end  = _filter_map.end();
-        
-        for ( ; map_it != map_end; map_it++) {
-            
-            if (map_it->first >= first_local_dof &&
-                map_it->first <  last_local_dof) {
-                
-                std::vector<std::pair<uint_t, real_t>>::const_iterator
-                vec_it  = map_it->second.begin(),
-                vec_end = map_it->second.end();
-                
-                for ( ; vec_it != vec_end; vec_it++) {
-                    if (nonzero_vals.count(vec_it->first)) {
-                        
-                        if (dvs.is_design_parameter(map_it->first))
-                            MAST::Numerics::Utility::add
-                            (output, map_it->first, nonzero_vals[vec_it->first] * vec_it->second);
-                        else
-                            MAST::Numerics::Utility::set
-                            (output, map_it->first, nonzero_vals[map_it->first]);
-                    }
-                }
-            }
-        }
+        MatMult(_weight_matrix, input, output);
     }
-    
-    
-    template <typename ScalarType,
-              typename Vec1Type,
-              typename Vec2Type>
-    inline void
-    compute_filtered_values
-    (const MAST::Optimization::DesignParameterVector<ScalarType> &dvs,
-     const Vec1Type       &input,
-     Vec2Type             &output) const {
-        
-        Assert2(input.size() == _system.n_dofs(),
-                input.size(), _system.n_dofs(),
-                "Incompatible vector sizes");
-        Assert2(output.size() == _system.n_dofs(),
-                output.size(), _system.n_dofs(),
-                "Incompatible vector sizes");
-        
-        MAST::Numerics::Utility::setZero(output);
-        
-        const uint_t
-        first_local_dof = _system.get_dof_map().first_dof(_system.comm().rank()),
-        last_local_dof  = _system.get_dof_map().end_dof(_system.comm().rank());
 
-        std::map<uint_t, std::vector<std::pair<uint_t, real_t>>>::const_iterator
-        map_it   = _filter_map.begin(),
-        map_end  = _filter_map.end();
-        
-        for ( ; map_it != map_end; map_it++) {
-            
-            // The forward map only processes the local dofs.
-            if (map_it->first >= first_local_dof &&
-                map_it->first <  last_local_dof) {
-                
-                std::vector<std::pair<uint_t, real_t>>::const_iterator
-                vec_it  = map_it->second.begin(),
-                vec_end = map_it->second.end();
-                
-                for ( ; vec_it != vec_end; vec_it++) {
-                    if (dvs.is_design_parameter_index(map_it->first))
-                        MAST::Numerics::Utility::add
-                        (output, map_it->first,
-                         MAST::Numerics::Utility::get(input, vec_it->first) * vec_it->second);
-                    else
-                        MAST::Numerics::Utility::set
-                        (output, map_it->first,
-                         MAST::Numerics::Utility::get(input, vec_it->first));
-                }
-            }
-        }
-    }
     
     /*!
      *  Applies the reverse map, which is used for sensitivity analysis by first computing the sensitivty wrt filtered coefficients
      *  and then using the columns of the filter coefficient mattix to compute the sensitivity of unfiltered coefficients.
      */
-    template <typename ScalarType,
-              typename Vec1Type,
-              typename Vec2Type>
     inline void
-    compute_reverse_filtered_values
-    (const MAST::Optimization::DesignParameterVector<ScalarType> &dvs,
-     const Vec1Type       &input,
-     Vec2Type             &output) const {
+    compute_reverse_filtered_values(Vec       input,
+                                    Vec       output) const {
         
-        Assert2(input.size() == _system.n_dofs(),
-                input.size(), _system.n_dofs(),
-                "Incompatible vector sizes");
-        Assert2(output.size() == _system.n_dofs(),
-                output.size(), _system.n_dofs(),
-                "Incompatible vector sizes");
+//        Assert2(input.size() == _system.n_dofs(),
+//                input.size(), _system.n_dofs(),
+//                "Incompatible vector sizes");
+//        Assert2(output.size() == _system.n_dofs(),
+//                output.size(), _system.n_dofs(),
+//                "Incompatible vector sizes");
         
-        MAST::Numerics::Utility::setZero(output);
+        //MAST::Numerics::Utility::setZero(output);
         
-        const libMesh::DofMap
-        &dof_map = _system.get_dof_map();
+        MatMultTranspose(_weight_matrix, input, output);
+    }
+
+    
+    inline void
+    compute_reverse_filtered_values(libMesh::NumericVector<real_t>  &input,
+                                    libMesh::NumericVector<real_t>  &output) const {
         
-        std::map<uint_t, std::vector<std::pair<uint_t, real_t>>>::const_iterator
-        map_it   = _reverse_map.begin(),
-        map_end  = _reverse_map.end();
+//        Assert2(input.size() == _system.n_dofs(),
+//                input.size(), _system.n_dofs(),
+//                "Incompatible vector sizes");
+//        Assert2(output.size() == _system.n_dofs(),
+//                output.size(), _system.n_dofs(),
+//                "Incompatible vector sizes");
         
-        for ( ; map_it != map_end; map_it++) {
-            
-            // The reverse map requires processing of dofs that are local and in the send
-            // list. Hence, we use dof_map to check if the dof falls in this category.
-            if (dof_map.semilocal_index(map_it->first)) {
-                
-                std::vector<std::pair<uint_t, real_t>>::const_iterator
-                vec_it  = map_it->second.begin(),
-                vec_end = map_it->second.end();
-                
-                for ( ; vec_it != vec_end; vec_it++) {
-                    if (dvs.is_design_parameter_index(map_it->first))
-                        MAST::Numerics::Utility::add
-                        (output, map_it->first,
-                         MAST::Numerics::Utility::get(input, vec_it->first) * vec_it->second);
-                    else
-                        MAST::Numerics::Utility::set
-                        (output, map_it->first,
-                         MAST::Numerics::Utility::get(input, vec_it->first));
-                }
-            }
-        }
+        //MAST::Numerics::Utility::setZero(output);
+
+        this->compute_reverse_filtered_values
+        (dynamic_cast<libMesh::PetscVector<real_t>&>(input).vec(),
+         dynamic_cast<libMesh::PetscVector<real_t>&>(output).vec());
     }
 
     
@@ -341,7 +334,7 @@ public:
     /*!
      *  prints the filter data.
      */
-    template <typename ScalarType>
+    /*template <typename ScalarType>
     inline void
     print(//const MAST::Optimization::DesignParameterVector<ScalarType> &dvs,
           std::ostream         &o) const {
@@ -378,7 +371,7 @@ public:
             }
             std::cout << std::endl;
         }
-    }
+    }*/
     
     
 private:
@@ -563,6 +556,9 @@ private:
         
         std::map<const libMesh::Node*, real_t>
         node_sum;
+        
+        std::map<uint_t, std::vector<std::pair<uint_t, real_t>>>
+        filter_map;
         
         libMesh::MeshBase::const_node_iterator
         node_it      =  mesh.local_nodes_begin(),
@@ -771,8 +767,8 @@ private:
                     sum  += _radius - d_12;
                     dof_2 = mesh_adaptor.nodes[indices_dists[r].first]->dof_number(_system.number(), 0, 0);
                     
-                    _filter_map[dof_1].push_back(std::pair<uint_t, real_t>
-                                                 (dof_2, _radius - d_12));
+                    filter_map[dof_1].push_back(std::pair<uint_t, real_t>
+                                                (dof_2, _radius - d_12));
 
                     // add this dof to the local send list
                     if (dof_2 < first_local_dof ||
@@ -830,8 +826,8 @@ private:
                     sum += _radius - d_12;
                     
                     // add information to dof_1 node about this remote node
-                    _filter_map[dof_1].push_back(std::pair<uint_t, real_t>
-                                                 (dof_2, _radius - d_12));
+                    filter_map[dof_1].push_back(std::pair<uint_t, real_t>
+                                                (dof_2, _radius - d_12));
                     
                     // add this dof to the local send list
                     send_list.insert(dof_2);
@@ -859,7 +855,7 @@ private:
             dof_1 = node->dof_number(_system.number(), 0, 0);
 
             // filter coefficients for this node
-            std::vector<std::pair<uint_t, real_t>>& vec = _filter_map[dof_1];
+            std::vector<std::pair<uint_t, real_t>>& vec = filter_map[dof_1];
             
             // sum from the local nodes for the geometric filter for
             // the present node
@@ -873,6 +869,10 @@ private:
             }
         }
 
+        // use the prepared filtering data to initialize the sparse matrix.
+        _init_filter_matrix(filter_map);
+        
+        
         // now prepare the reverse map. The send list is sorted for later use.
         std::set<uint_t>::const_iterator
         s_it  = send_list.begin(),
@@ -881,7 +881,7 @@ private:
         _forward_send_list.reserve(send_list.size());
         for ( ; s_it != s_end; s_it++) _forward_send_list.push_back(*s_it);
         
-        _init_reverse_map(_filter_map, _reverse_map);
+        /*_init_reverse_map(filter_map, _reverse_map);
         
         // compute the largest element size
         libMesh::MeshBase::const_element_iterator
@@ -894,7 +894,7 @@ private:
             
             if (_fe_size < d_12)
                 _fe_size = d_12;
-        }
+        }*/
 
         _system.comm().min(_fe_size);
     }
@@ -906,13 +906,14 @@ private:
      */
     inline void _init() {
         
-        Assert0(!_filter_map.size(), "Filter already initialized");
-        
         libMesh::MeshBase& mesh = _system.get_mesh();
         
         // currently implemented for replicated mesh
         Assert0(mesh.is_replicated(), "Function implemented only for replicated mesh");
         
+        std::map<uint_t, std::vector<std::pair<uint_t, real_t>>>
+        filter_map;
+
         // iterate over all nodes to compute the
         libMesh::MeshBase::const_node_iterator
         node_it_1    =  mesh.nodes_begin(),
@@ -961,7 +962,7 @@ private:
                         sum  += _radius - d_12;
                         dof_2 = (*node_it_2)->dof_number(_system.number(), 0, 0);
                         
-                        _filter_map[dof_1].push_back(std::pair<uint_t, real_t>(dof_2, _radius - d_12));
+                        filter_map[dof_1].push_back(std::pair<uint_t, real_t>(dof_2, _radius - d_12));
                         
                         // add this dof to the local send list if it is not a local dof
                         if (dof_2 < first_local_dof ||
@@ -974,7 +975,7 @@ private:
                 
                 // with the coefficients computed for dof_1, divide each coefficient
                 // with the sum
-                std::vector<std::pair<uint_t, real_t>>& vec = _filter_map[dof_1];
+                std::vector<std::pair<uint_t, real_t>>& vec = filter_map[dof_1];
                 for (uint_t i=0; i<vec.size(); i++) {
                     
                     vec[i].second /= sum;
@@ -984,6 +985,10 @@ private:
             }
         }
         
+        // use the prepared filtering data to initialize the sparse matrix.
+        _init_filter_matrix(filter_map);
+
+        
         // now prepare the reverse map. The send list is sorted for later use.
         std::set<uint_t>::const_iterator
         s_it  = send_list.begin(),
@@ -992,7 +997,7 @@ private:
         _forward_send_list.reserve(send_list.size());
         for ( ; s_it != s_end; s_it++) _forward_send_list.push_back(*s_it);
         
-        _init_reverse_map(_filter_map, _reverse_map);
+        /*_init_reverse_map(_filter_map, _reverse_map);
 
         // compute the largest element size
         libMesh::MeshBase::const_element_iterator
@@ -1006,7 +1011,7 @@ private:
             if (_fe_size < d_12)
                 _fe_size = d_12;
         }
-        
+        */
     }
     
     
@@ -1028,6 +1033,95 @@ private:
                 reverse_map[vec[i].first].push_back(std::pair<uint_t, real_t>(it->first, vec[i].second));
         }
     }
+    
+    inline void
+    _init_filter_matrix
+    (const std::map<uint_t, std::vector<std::pair<uint_t, real_t>>>& filter_map) {
+        
+        const uint_t
+        n_vals          = _system.n_dofs(),
+        n_local         = _system.get_dof_map().n_dofs_on_processor(_system.processor_id()),
+        first_local_dof = _system.get_dof_map().first_dof(_system.comm().rank()),
+        last_local_dof  = _system.get_dof_map().end_dof(_system.comm().rank());
+
+        PetscErrorCode   ierr;
+     
+        std::vector<int>
+        n_nz(n_local, 0),
+        n_oz(n_local, 0);
+
+        // initialize the data for the sparsity pattern of the matrix
+        std::map<uint_t, std::vector<std::pair<uint_t, real_t>>>::const_iterator
+        it   =  filter_map.begin(),
+        end  =  filter_map.end();
+        
+        for ( ; it!=end; it++) {
+            
+            const std::vector<std::pair<uint_t, real_t>>
+            &vec = it->second;
+            
+            for (uint_t i=0; i<vec.size(); i++) {
+                uint_t
+                dof_id = vec[i].first;
+                if (dof_id >= first_local_dof && dof_id <  last_local_dof)
+                    n_nz[it->first - first_local_dof]++;
+                else
+                    n_oz[it->first - first_local_dof]++;
+            }
+        }
+
+        
+        ierr = MatCreate(_system.comm().get(), &_weight_matrix);
+        CHKERRABORT(_system.comm().get(), ierr);
+        ierr = MatSetSizes(_weight_matrix, n_local, n_local, n_vals, n_vals);
+        CHKERRABORT(_system.comm().get(), ierr);
+
+        std::string nm = _system.name() + "_";
+        ierr = MatSetOptionsPrefix(_weight_matrix, nm.c_str());
+        CHKERRABORT(_system.comm().get(), ierr);
+
+        ierr = MatSetFromOptions(_weight_matrix);
+        CHKERRABORT(_system.comm().get(), ierr);
+        
+        ierr = MatSeqAIJSetPreallocation(_weight_matrix,
+                                         n_vals,
+                                         (PetscInt*)&n_nz[0]);
+        CHKERRABORT(_system.comm().get(), ierr);
+        ierr = MatMPIAIJSetPreallocation(_weight_matrix,
+                                         0,
+                                         (PetscInt*)&n_nz[0],
+                                         0,
+                                         (PetscInt*)&n_oz[0]);
+        CHKERRABORT(_system.comm().get(), ierr);
+        ierr = MatSetOption(_weight_matrix,
+                            MAT_NEW_NONZERO_ALLOCATION_ERR,
+                            PETSC_TRUE);
+        CHKERRABORT(_system.comm().get(), ierr);
+
+        // now populate the matrix
+        it   =  filter_map.begin();
+        end  =  filter_map.end();
+        
+        for ( ; it!=end; it++) {
+            
+            const std::vector<std::pair<uint_t, real_t>>
+            &vec = it->second;
+            
+            for (uint_t i=0; i<vec.size(); i++) {
+                MatSetValue(_weight_matrix,
+                            it->first,
+                            vec[i].first,
+                            vec[i].second,
+                            INSERT_VALUES);
+            }
+        }
+        
+        MatAssemblyBegin(_weight_matrix, MAT_FINAL_ASSEMBLY);
+        CHKERRABORT(_system.comm().get(), ierr);
+        MatAssemblyEnd(_weight_matrix, MAT_FINAL_ASSEMBLY);
+        CHKERRABORT(_system.comm().get(), ierr);
+    }
+    
     
     /*!
      *   system on which the level set discrete function is defined
@@ -1055,18 +1149,22 @@ private:
      *   Algebraic relation between filtered level set values and the
      *   design variables \f$ \tilde{\phi}_i = B_{ij} \phi_j \f$
      */
-    std::map<uint_t, std::vector<std::pair<uint_t, real_t>>> _filter_map;
+    //std::map<uint_t, std::vector<std::pair<uint_t, real_t>>> _filter_map;
     
     /*!
      * this map stores the columns of the matrix, which is required for sensitivity analysis
      */
-    std::map<uint_t, std::vector<std::pair<uint_t, real_t>>> _reverse_map;
+    //std::map<uint_t, std::vector<std::pair<uint_t, real_t>>> _reverse_map;
     
     /*!
      *   vector of dof ids that the current processor depends on.
      */
     std::vector<uint_t> _forward_send_list;
     
+    /*!
+     * Sparse Matrix object that stores the filtering matrix. This is used for both both forward and reverse operations
+     */
+    Mat _weight_matrix;
 };
 
 

--- a/include/mast/numerics/utility.hpp
+++ b/include/mast/numerics/utility.hpp
@@ -31,6 +31,7 @@
 #include <libmesh/numeric_vector.h>
 #include <libmesh/sparse_matrix.h>
 #include <libmesh/parallel.h>
+#include <libmesh/system.h>
 
 namespace MAST {
 namespace Numerics {
@@ -134,6 +135,41 @@ finalize(libMesh::SparseMatrix<real_t>& m) { m.close();}
 template <typename P1, int P2, typename P3>
 inline void
 finalize(Eigen::SparseMatrix<P1, P2, P3>& m) { m.makeCompressed();}
+
+
+template <typename ScalarType>
+inline void resize(std::vector<ScalarType>& v, uint_t n) {
+
+    v.resize(n, ScalarType());
+}
+
+
+template <typename ScalarType>
+inline void resize(Eigen::Matrix<ScalarType, Eigen::Dynamic, 1>& v, uint_t n) {
+
+    v = Eigen::Matrix<ScalarType, Eigen::Dynamic, 1>::Zero(n);
+}
+
+
+template <typename ValType>
+inline std::unique_ptr<ValType>
+build(const libMesh::System& sys) {
+
+    std::unique_ptr<ValType> rval(new ValType);
+    MAST::Numerics::Utility::resize(*rval, sys.n_dofs());
+    
+    return rval;
+}
+
+
+template <>
+inline std::unique_ptr<libMesh::NumericVector<real_t>>
+build(const libMesh::System& sys) {
+
+    return std::unique_ptr<libMesh::NumericVector<real_t>>
+    (sys.solution->zero_clone().release());
+}
+
 
 
 template <typename ScalarType, typename VecType>

--- a/include/mast/optimization/solvers/gcmma_interface.hpp
+++ b/include/mast/optimization/solvers/gcmma_interface.hpp
@@ -97,7 +97,8 @@ public:
     max_iters                     (1000),
     n_rel_change_iters            (5),
     write_internal_iteration_data (false),
-    _feval                        (nullptr)
+    _feval                        (nullptr),
+    _total_iter                   (0)
     { }
 
     

--- a/include/mast/optimization/topology/simp/libmesh/volume.hpp
+++ b/include/mast/optimization/topology/simp/libmesh/volume.hpp
@@ -156,9 +156,9 @@ public:
         n_density_dofs = c.rho_sys->n_dofs();
 
         MAST::Numerics::Utility::setZero(sens);
-        std::vector<ScalarType>
-        v (n_density_dofs, ScalarType()),
-        v_filtered (n_density_dofs, ScalarType());
+        std::unique_ptr<VecType>
+        v (MAST::Numerics::Utility::build<VecType>(*c.rho_sys).release()),
+        v_filtered (MAST::Numerics::Utility::build<VecType>(*c.rho_sys).release());
 
         // iterate over each element, initialize it and get the relevant
         // analysis quantities
@@ -192,28 +192,25 @@ public:
                 // for each element. So, if the dof was found for this
                 // element, then we will simply set the element sensitivity
                 // to be the averaged value
-                v[density_dof_ids[i]]  +=  e_vol/(1. * c.elem->n_nodes());
+                MAST::Numerics::Utility::add(*v,
+                                             density_dof_ids[i],
+                                             e_vol/(1. * c.elem->n_nodes()));
             }
         }
         
+        MAST::Numerics::Utility::finalize(*v);
+
         // Now, combine the sensitivty with the filtering data
-        filter.compute_reverse_filtered_values(dvs, v, v_filtered);
-        
-        // copy the results back to sens
-        const typename MAST::Optimization::DesignParameterVector<ScalarType>::dv_id_param_map_t
-        &dv_id_map = dvs.get_dv_map();
-        
-        typename MAST::Optimization::DesignParameterVector<ScalarType>::dv_id_param_map_t::const_iterator
-        it   = dv_id_map.begin(),
-        end  = dv_id_map.end();
+        filter.compute_reverse_filtered_values(*v, *v_filtered);
 
         uint_t
         idx  = 0;
 
-        for ( ; it != end; it++) {
-            
-            idx = dvs.get_data_for_parameter(*it->second).template get<int>("dof_id");
-            sens[it->first] = v_filtered[idx];
+        // copy the results back to sens
+        for (uint_t i=dvs.local_begin(); i<dvs.local_end(); i++) {
+
+            idx = dvs.get_data_for_parameter(dvs[i]).template get<int>("dof_id");
+            sens[i] = MAST::Numerics::Utility::get(*v_filtered, idx);
         }
 
         MAST::Numerics::Utility::comm_sum(c.rho_sys->comm(), sens);

--- a/include/mast/optimization/topology/simp/libmesh/volume.hpp
+++ b/include/mast/optimization/topology/simp/libmesh/volume.hpp
@@ -241,9 +241,10 @@ public:
         n_density_dofs = c.rho_sys->n_dofs();
 
         MAST::Numerics::Utility::setZero(sens);
-        std::vector<ScalarType>
-        v (n_density_dofs, ScalarType()),
-        v_filtered (n_density_dofs, ScalarType());
+        
+        std::unique_ptr<VecType>
+        v (MAST::Numerics::Utility::build<VecType>(*c.rho_sys).release()),
+        v_filtered (MAST::Numerics::Utility::build<VecType>(*c.rho_sys).release());
 
         // iterate over each element, initialize it and get the relevant
         // analysis quantities
@@ -279,31 +280,29 @@ public:
                 // for each element. So, if the dof was found for this
                 // element, then we will simply set the element sensitivity
                 // to be the averaged value
-                v[density_dof_ids[i]]  +=  e_vol/(1. * c.elem->n_nodes()) *
-                density_filter.filter_derivative(MAST::Numerics::Utility::get
-                                                 (density, n.dof_number(sys_num, 0, 0)),
-                                                 1.);
+                MAST::Numerics::Utility::add
+                (*v,
+                 density_dof_ids[i],
+                 e_vol/(1. * c.elem->n_nodes()) *
+                 density_filter.filter_derivative(MAST::Numerics::Utility::get
+                                                  (density, n.dof_number(sys_num, 0, 0)),
+                                                  1.));
             }
         }
         
+        MAST::Numerics::Utility::finalize(*v);
+        
         // Now, combine the sensitivty with the filtering data
-        geom_filter.compute_reverse_filtered_values(dvs, v, v_filtered);
+        geom_filter.compute_reverse_filtered_values(*v, *v_filtered);
         
-        // copy the results back to sens
-        const typename MAST::Optimization::DesignParameterVector<ScalarType>::dv_id_param_map_t
-        &dv_id_map = dvs.get_dv_map();
-        
-        typename MAST::Optimization::DesignParameterVector<ScalarType>::dv_id_param_map_t::const_iterator
-        it   = dv_id_map.begin(),
-        end  = dv_id_map.end();
-
         uint_t
         idx  = 0;
 
-        for ( ; it != end; it++) {
-            
-            idx = dvs.get_data_for_parameter(*it->second).template get<int>("dof_id");
-            sens[it->first] = v_filtered[idx];
+        // copy the results back to sens
+        for (uint_t i=dvs.local_begin(); i<dvs.local_end(); i++) {
+
+            idx = dvs.get_data_for_parameter(dvs[i]).template get<int>("dof_id");
+            sens[i] = MAST::Numerics::Utility::get(*v_filtered, idx);
         }
 
         MAST::Numerics::Utility::comm_sum(c.rho_sys->comm(), sens);

--- a/include/mast/solvers/petsc/linear_solver.hpp
+++ b/include/mast/solvers/petsc/linear_solver.hpp
@@ -60,7 +60,7 @@ public:
      * pass this to the \p KSPSetOptionsPrefix method. This allows specific
      * selection of solver options for different linear solvers in a code.
      */
-    inline void init(Mat A, std::string* scope = nullptr) {
+    inline void init(Mat A, const std::string* scope = nullptr) {
 
         Assert0(!_A, "solver already initialized");
 
@@ -75,7 +75,8 @@ public:
 
         if (scope) {
             
-            ierr = KSPSetOptionsPrefix(_ksp, scope->c_str());
+            std::string nm = *scope + "_";
+            ierr = KSPSetOptionsPrefix(_ksp, nm.c_str());
             CHKERRABORT(_comm, ierr);
         }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ target_link_libraries(mast_catch_tests mast)
 # TODO: May be better to use Catch2's built in CMake support rather than manually adding through ctest
 
 add_subdirectory(fe)
+add_subdirectory(mesh)
 add_subdirectory(optimization)
 add_subdirectory(physics)
 

--- a/tests/mesh/CMakeLists.txt
+++ b/tests/mesh/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(libmesh)

--- a/tests/mesh/libmesh/CMakeLists.txt
+++ b/tests/mesh/libmesh/CMakeLists.txt
@@ -1,0 +1,16 @@
+target_sources(mast_catch_tests
+               PRIVATE
+               ${CMAKE_CURRENT_LIST_DIR}/geometric_filter.cpp)
+
+target_include_directories(mast_catch_tests
+                           PRIVATE
+                           ${PROJECT_SOURCE_DIR}/examples)
+
+#geometric filter transpose operation
+add_test(NAME GeometricFilterTranspose
+         COMMAND $<TARGET_FILE:mast_catch_tests> -w NoTests "geometric_filter_transpose")
+set_tests_properties(GeometricFilterTranspose
+                    PROPERTIES
+                    LABELS "SEQ"
+                    FIXTURES_SETUP     GeometricFilterTranspose)
+

--- a/tests/mesh/libmesh/geometric_filter.cpp
+++ b/tests/mesh/libmesh/geometric_filter.cpp
@@ -1,0 +1,135 @@
+/*
+* MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+* Copyright (C) 2013-2020  Manav Bhatia and MAST authors
+*
+* This library is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* This library is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this library; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+// Catch includes
+#include "catch.hpp"
+
+// MAST includes
+#ifndef MAST_TESTING
+#define MAST_TESTING 1
+#endif
+
+#include <structural/example_6/example_6.cpp>
+
+// Test includes
+#include <test_helpers.h>
+
+extern libMesh::LibMeshInit* p_global_init;
+
+namespace MAST {
+namespace Test {
+namespace Mesh {
+namespace libMesh {
+namespace GeometricFilter {
+
+
+
+
+inline void test_filter_transpose_operation()  {
+
+    std::vector<std::string> arguments = {"filter_radius=0.05"};
+
+    std::vector<char*> argv;
+    for (const auto& arg : arguments)
+        argv.push_back((char*)arg.data());
+    argv.push_back(nullptr);
+
+    MAST::Utility::GetPotWrapper input(argv.size() - 1, argv.data());
+
+    using traits_t    = MAST::Examples::Structural::Example6::Traits<real_t, real_t, real_t, MAST::Mesh::Generation::Bracket2D>;
+    
+    typename traits_t::ex_init_t ex_init(p_global_init->comm(), input);
+
+    MAST::Optimization::DesignParameterVector<traits_t::scalar_t> dvs(p_global_init->comm());
+    ex_init.model->init_simp_dvs(ex_init, dvs);
+
+    const uint_t
+    n_rho_vals      = ex_init.rho_sys->n_dofs(),
+    first_local_rho = ex_init.rho_sys->get_dof_map().first_dof(ex_init.rho_sys->comm().rank()),
+    last_local_rho  = ex_init.rho_sys->get_dof_map().end_dof(ex_init.rho_sys->comm().rank()),
+    qoi_dof         = last_local_rho-1;
+    
+    std::unique_ptr<typename traits_t::assembled_vector_t>
+    rho_base(ex_init.rho_sys->solution->zero_clone().release()),
+    vec1(ex_init.rho_sys->solution->zero_clone().release()),
+    rho_sens_filtered(ex_init.rho_sys->solution->zero_clone().release());
+
+    /*for (uint_t qoi_dof=0; qoi_dof<n_rho_vals; qoi_dof++)*/ {
+        
+        
+        for (uint_t i=0; i<n_rho_vals; i++) {
+            
+            rho_base->zero();
+            rho_base->set(i, 1.);
+            rho_base->close();
+            
+            ex_init.filter->template compute_filtered_values
+            <traits_t::scalar_t,
+            typename traits_t::assembled_vector_t,
+            typename traits_t::assembled_vector_t>
+            (dvs, *rho_base, *vec1);
+            
+            vec1->close();
+            
+            rho_sens_filtered->set(i, vec1->el(qoi_dof));
+        }
+        
+        rho_sens_filtered->close();
+        
+        rho_base->zero();
+        rho_base->set(qoi_dof, 1.);
+        rho_base->close();
+        
+        ex_init.filter->template compute_reverse_filtered_values
+        <traits_t::scalar_t,
+        typename traits_t::assembled_vector_t,
+        typename traits_t::assembled_vector_t>
+        (dvs, *rho_base, *vec1);
+        
+        vec1->close();
+        
+        Eigen::Matrix<traits_t::scalar_t, Eigen::Dynamic, 1>
+        v1  = Eigen::Matrix<traits_t::scalar_t, Eigen::Dynamic, 1>::Zero(n_rho_vals),
+        v2  = Eigen::Matrix<traits_t::scalar_t, Eigen::Dynamic, 1>::Zero(n_rho_vals);
+        
+        for (uint_t i=0; i<n_rho_vals; i++) {
+            v1[i] = rho_sens_filtered->el(i);
+            v2[i] = vec1->el(i);
+        }
+        
+        CHECK_THAT(MAST::Test::eigen_matrix_to_std_vector(v1),
+                   Catch::Approx(MAST::Test::eigen_matrix_to_std_vector(v2)));
+    }
+}
+
+
+
+TEST_CASE("geometric_filter_transpose",
+          "[Optimization][Topology][Filter]") {
+    
+    test_filter_transpose_operation();
+}
+
+} // namespace SIMP
+} // namespace Topology
+} // namespace Optimization
+} // namespace Test
+} // namespace MAST
+
+

--- a/tests/mesh/libmesh/geometric_filter.cpp
+++ b/tests/mesh/libmesh/geometric_filter.cpp
@@ -78,11 +78,8 @@ inline void test_filter_transpose_operation()  {
             rho_base->set(i, 1.);
             rho_base->close();
             
-            ex_init.filter->template compute_filtered_values
-            <traits_t::scalar_t,
-            typename traits_t::assembled_vector_t,
-            typename traits_t::assembled_vector_t>
-            (dvs, *rho_base, *vec1);
+            ex_init.filter->compute_filtered_values
+            (*rho_base, *vec1);
             
             vec1->close();
             
@@ -95,11 +92,8 @@ inline void test_filter_transpose_operation()  {
         rho_base->set(qoi_dof, 1.);
         rho_base->close();
         
-        ex_init.filter->template compute_reverse_filtered_values
-        <traits_t::scalar_t,
-        typename traits_t::assembled_vector_t,
-        typename traits_t::assembled_vector_t>
-        (dvs, *rho_base, *vec1);
+        ex_init.filter->compute_reverse_filtered_values
+        (*rho_base, *vec1);
         
         vec1->close();
         

--- a/tests/mesh/libmesh/geometric_filter.cpp
+++ b/tests/mesh/libmesh/geometric_filter.cpp
@@ -43,14 +43,13 @@ namespace GeometricFilter {
 
 inline void test_filter_transpose_operation()  {
 
-    std::vector<std::string> arguments = {"filter_radius=0.05"};
+    char *args[] = {
+        (char*)" ",
+        (char*)"filter_radius=0.05",
+        NULL
+    };
 
-    std::vector<char*> argv;
-    for (const auto& arg : arguments)
-        argv.push_back((char*)arg.data());
-    argv.push_back(nullptr);
-
-    MAST::Utility::GetPotWrapper input(argv.size() - 1, argv.data());
+    MAST::Utility::GetPotWrapper input(2, args);
 
     using traits_t    = MAST::Examples::Structural::Example6::Traits<real_t, real_t, real_t, MAST::Mesh::Generation::Bracket2D>;
     

--- a/tests/optimization/solvers/gcmma_interface.cpp
+++ b/tests/optimization/solvers/gcmma_interface.cpp
@@ -95,6 +95,7 @@ TEST_CASE("gcmma_interface",
     MAST::Optimization::Solvers::GCMMAInterface<RosenbrockFunction>
     opt(p_global_init->comm());
     opt.set_function_evaluation(f);
+    opt.init();
     
     opt.optimize();
     


### PR DESCRIPTION
* This fixes a bug in geometric filtering `compute_reverse_filtered_values` for MPI runs with multiple ranks 
* The filtering operator matrix is now a PETSc sparse matrix, which allows for consistent operations
* changes to the examples and other classes for consistency with with the changes to geometric filter API.