### PR TITLE
Linear density discretization for Topology Optimization

### DIFF
--- a/examples/structural/example_5/example_5.cpp
+++ b/examples/structural/example_5/example_5.cpp
@@ -242,24 +242,25 @@ public:
     using matrix_t  = Eigen::Matrix<scalar_t, Eigen::Dynamic, Eigen::Dynamic>;
     
     ElemOps(context_t  &c):
-    heaviside       (nullptr),
-    density         (nullptr),
-    E               (nullptr),
-    dt              (nullptr),
-    nu              (nullptr),
-    alpha           (nullptr),
-    press           (nullptr),
-    area            (nullptr),
-    _fe_data        (nullptr),
-    _fe_side_data   (nullptr),
-    _fe_var         (nullptr),
-    _fe_side_var    (nullptr),
-    _density_fe_var (nullptr),
-    _density_field  (nullptr),
-    _prop           (nullptr),
-    _energy         (nullptr),
-    _temp_load      (nullptr),
-    _p_load         (nullptr) {
+    heaviside            (nullptr),
+    density              (nullptr),
+    E                    (nullptr),
+    dt                   (nullptr),
+    nu                   (nullptr),
+    alpha                (nullptr),
+    press                (nullptr),
+    area                 (nullptr),
+    _fe_data             (nullptr),
+    _fe_side_data        (nullptr),
+    _fe_var              (nullptr),
+    _fe_side_var         (nullptr),
+    _density_fe_var      (nullptr),
+    _density_sens_fe_var (nullptr),
+    _density_field       (nullptr),
+    _prop                (nullptr),
+    _energy              (nullptr),
+    _temp_load           (nullptr),
+    _p_load              (nullptr) {
         
         _fe_data       = new typename TraitsType::fe_data_t;
         _fe_data->init(c.ex_init.q_order,
@@ -354,7 +355,8 @@ public:
 
         delete _density_field;
         delete _density_fe_var;
-        
+        delete _density_sens_fe_var;
+
         delete _fe_var;
         delete _fe_side_var;
         delete _fe_side_data;

--- a/examples/structural/example_6/example_6.cpp
+++ b/examples/structural/example_6/example_6.cpp
@@ -77,40 +77,42 @@ public:
 
     InitExample(libMesh::Parallel::Communicator &mpi_comm,
                 MAST::Utility::GetPotWrapper    &inp):
-    comm      (mpi_comm),
-    input     (inp),
-    model     (new ModelType),
-    q_type    (libMesh::QGAUSS),
-    q_order   (libMesh::SECOND),
-    fe_order  (libMesh::FIRST),
-    fe_family (libMesh::LAGRANGE),
-    mesh      (new libMesh::DistributedMesh(comm)),
-    eq_sys    (new libMesh::EquationSystems(*mesh)),
-    sys       (&eq_sys->add_system<libMesh::NonlinearImplicitSystem>("structural")),
-    rho_sys   (&eq_sys->add_system<libMesh::ExplicitSystem>("density")),
-    filter    (nullptr),
-    p_side_id (-1),
-    penalty   (0.),
-    beta      (0.),
-    eta       (0.) {
+    comm          (mpi_comm),
+    input         (inp),
+    model         (new ModelType),
+    sol_q_type    (libMesh::QGAUSS),
+    sol_q_order   (libMesh::SECOND),
+    sol_fe_order  (libMesh::FIRST),
+    sol_fe_family (libMesh::LAGRANGE),
+    rho_fe_order  (libMesh::FIRST),
+    rho_fe_family (libMesh::LAGRANGE),
+    mesh          (new libMesh::DistributedMesh(comm)),
+    eq_sys        (new libMesh::EquationSystems(*mesh)),
+    sys           (&eq_sys->add_system<libMesh::NonlinearImplicitSystem>("structural")),
+    rho_sys       (&eq_sys->add_system<libMesh::ExplicitSystem>("density")),
+    filter        (nullptr),
+    p_side_id     (-1),
+    penalty       (0.),
+    beta          (0.),
+    eta           (0.) {
         
         std::string
         t = input("q_order", "quadrature order", "second");
-        q_order = libMesh::Utility::string_to_enum<libMesh::Order>(t);
+        sol_q_order = libMesh::Utility::string_to_enum<libMesh::Order>(t);
 
         t = input("fe_order", "finite element interpolation order", "first");
-        fe_order = libMesh::Utility::string_to_enum<libMesh::Order>(t);
+        sol_fe_order = libMesh::Utility::string_to_enum<libMesh::Order>(t);
 
         model->init_analysis_mesh(*this, *mesh);
 
         // displacement variables for elasticity solution
-        sys->add_variable("u_x", libMesh::FEType(fe_order, fe_family));
-        sys->add_variable("u_y", libMesh::FEType(fe_order, fe_family));
+        sys->add_variable("u_x", libMesh::FEType(sol_fe_order, sol_fe_family));
+        sys->add_variable("u_y", libMesh::FEType(sol_fe_order, sol_fe_family));
         if (ModelType::dim == 3)
-            sys->add_variable("u_z", libMesh::FEType(fe_order, fe_family));
+            sys->add_variable("u_z", libMesh::FEType(sol_fe_order, sol_fe_family));
         
         // density field
-        rho_sys->add_variable("rho", libMesh::FEType(fe_order, fe_family));
+        rho_sys->add_variable("rho", libMesh::FEType(rho_fe_order, rho_fe_family));
         
         model->init_analysis_dirichlet_conditions(*this);
         
@@ -147,10 +149,12 @@ public:
     libMesh::Parallel::Communicator             &comm;
     MAST::Utility::GetPotWrapper                &input;
     ModelType                                   *model;
-    libMesh::QuadratureType                      q_type;
-    libMesh::Order                               q_order;
-    libMesh::Order                               fe_order;
-    libMesh::FEFamily                            fe_family;
+    libMesh::QuadratureType                      sol_q_type;
+    libMesh::Order                               sol_q_order;
+    libMesh::Order                               sol_fe_order;
+    libMesh::FEFamily                            sol_fe_family;
+    libMesh::Order                               rho_fe_order;
+    libMesh::FEFamily                            rho_fe_family;
     libMesh::DistributedMesh                    *mesh;
     libMesh::EquationSystems                    *eq_sys;
     libMesh::NonlinearImplicitSystem            *sys;
@@ -260,60 +264,69 @@ public:
     using matrix_t  = Eigen::Matrix<scalar_t, Eigen::Dynamic, Eigen::Dynamic>;
     
     ElemOps(context_t  &c):
-    heaviside       (nullptr),
-    density         (nullptr),
-    E               (nullptr),
-    dt              (nullptr),
-    nu              (nullptr),
-    alpha           (nullptr),
-    press           (nullptr),
-    area            (nullptr),
-    _fe_data        (nullptr),
-    _fe_side_data   (nullptr),
-    _fe_var         (nullptr),
-    _fe_side_var    (nullptr),
-    _density_fe_var (nullptr),
-    _density_field  (nullptr),
-    _prop           (nullptr),
-    _energy         (nullptr),
-    _temp_load      (nullptr),
-    _p_load         (nullptr) {
+    heaviside           (nullptr),
+    density             (nullptr),
+    E                   (nullptr),
+    dt                  (nullptr),
+    nu                  (nullptr),
+    alpha               (nullptr),
+    press               (nullptr),
+    area                (nullptr),
+    _sol_fe_data        (nullptr),
+    _sol_fe_side_data   (nullptr),
+    _sol_fe_var         (nullptr),
+    _sol_fe_side_var    (nullptr),
+    _density_fe_basis   (nullptr),
+    _density_fe_deriv   (nullptr),
+    _density_fe_var     (nullptr),
+    _density_sens_fe_var(nullptr),
+    _density_field      (nullptr),
+    _prop               (nullptr),
+    _energy             (nullptr),
+    _temp_load          (nullptr),
+    _p_load             (nullptr) {
         
-        _fe_data       = new typename TraitsType::fe_data_t;
-        _fe_data->init(c.ex_init.q_order,
-                       c.ex_init.q_type,
-                       c.ex_init.fe_order,
-                       c.ex_init.fe_family);
-        _fe_side_data  = new typename TraitsType::fe_side_data_t;
-        _fe_side_data->init(c.ex_init.q_order,
-                            c.ex_init.q_type,
-                            c.ex_init.fe_order,
-                            c.ex_init.fe_family);
-        _fe_var        = new typename TraitsType::fe_var_t;
-        _fe_side_var   = new typename TraitsType::fe_var_t;
+        _sol_fe_data       = new typename TraitsType::fe_data_t;
+        _sol_fe_data->init(c.ex_init.sol_q_order,
+                           c.ex_init.sol_q_type,
+                           c.ex_init.sol_fe_order,
+                           c.ex_init.sol_fe_family);
+        _sol_fe_side_data  = new typename TraitsType::fe_side_data_t;
+        _sol_fe_side_data->init(c.ex_init.sol_q_order,
+                                c.ex_init.sol_q_type,
+                                c.ex_init.sol_fe_order,
+                                c.ex_init.sol_fe_family);
+        _sol_fe_var        = new typename TraitsType::fe_var_t;
+        _sol_fe_side_var   = new typename TraitsType::fe_var_t;
         
+        _density_fe_basis  = new typename
+        TraitsType::fe_basis_t(libMesh::FEType(c.ex_init.rho_fe_order,
+                                               c.ex_init.rho_fe_family));
+        _density_fe_deriv  = new typename TraitsType::fe_shape_t;
+
         _density_fe_var      = new typename TraitsType::density_fe_var_t;
         _density_sens_fe_var = new typename TraitsType::density_fe_var_t;
         _density_field       = new typename TraitsType::density_field_t;
         
         // associate variables with the shape functions
-        _fe_var->set_fe_shape_data(_fe_data->fe_derivative());
-        _fe_side_var->set_fe_shape_data(_fe_side_data->fe_derivative());
+        _sol_fe_var->set_fe_shape_data(_sol_fe_data->fe_derivative());
+        _sol_fe_side_var->set_fe_shape_data(_sol_fe_side_data->fe_derivative());
         
         // tell the FE computations which quantities are needed for computation
-        _fe_data->fe_basis().set_compute_dphi_dxi(true);
+        _sol_fe_data->fe_basis().set_compute_dphi_dxi(true);
         
-        _fe_data->fe_derivative().set_compute_dphi_dx(true);
-        _fe_data->fe_derivative().set_compute_detJxW(true);
+        _sol_fe_data->fe_derivative().set_compute_dphi_dx(true);
+        _sol_fe_data->fe_derivative().set_compute_detJxW(true);
         
-        _fe_side_data->fe_basis().set_compute_dphi_dxi(true);
-        _fe_side_data->fe_derivative().set_compute_normal(true);
-        _fe_side_data->fe_derivative().set_compute_detJxW(true);
+        _sol_fe_side_data->fe_basis().set_compute_dphi_dxi(true);
+        _sol_fe_side_data->fe_derivative().set_compute_normal(true);
+        _sol_fe_side_data->fe_derivative().set_compute_detJxW(true);
         
-        _fe_var->set_compute_du_dx(true);
+        _sol_fe_var->set_compute_du_dx(true);
         
-        _density_fe_var->set_fe_shape_data(_fe_data->fe_derivative());
-        _density_sens_fe_var->set_fe_shape_data(_fe_data->fe_derivative());
+        _density_fe_deriv->set_fe_basis(*_density_fe_basis);
+        _density_fe_var->set_fe_shape_data(*_density_fe_deriv);
+        _density_sens_fe_var->set_fe_shape_data(*_density_fe_deriv);
         _density_field->set_fe_object_and_component(*_density_fe_var, 0);
         _density_field->set_derivative_fe_object_and_component(*_density_sens_fe_var, 0);
 
@@ -350,9 +363,9 @@ public:
         _temp_load->set_temperature(*dt);
         
         // tell physics kernels about the FE discretization information
-        _energy->set_fe_var_data(*_fe_var);
-        _p_load->set_fe_var_data(*_fe_side_var);
-        _temp_load->set_fe_var_data(*_fe_var);
+        _energy->set_fe_var_data(*_sol_fe_var);
+        _p_load->set_fe_var_data(*_sol_fe_side_var);
+        _temp_load->set_fe_var_data(*_sol_fe_var);
     }
     
     virtual ~ElemOps() {
@@ -373,11 +386,14 @@ public:
 
         delete _density_field;
         delete _density_fe_var;
-        
-        delete _fe_var;
-        delete _fe_side_var;
-        delete _fe_side_data;
-        delete _fe_data;
+        delete _density_sens_fe_var;
+        delete _density_fe_deriv;
+        delete _density_fe_basis;
+
+        delete _sol_fe_var;
+        delete _sol_fe_side_var;
+        delete _sol_fe_side_data;
+        delete _sol_fe_data;
     }
     
     
@@ -391,9 +407,11 @@ public:
                         typename TraitsType::element_matrix_t *jac) {
         
 
-        c.fe = &_fe_data->fe_derivative();
-        _fe_data->reinit(c);
-        _fe_var->init(c, sol_v);
+        c.fe = &_sol_fe_data->fe_derivative();
+        _sol_fe_data->reinit(c);
+        _sol_fe_var->init(c, sol_v);
+        _density_fe_basis->reinit(*c.elem, _sol_fe_data->quadrature());
+        _density_fe_deriv->reinit(c);
         _density_fe_var->init(c, density_v);
 
         _energy->compute(c, res, jac);
@@ -402,9 +420,9 @@ public:
         for (uint_t s=0; s<c.elem->n_sides(); s++)
             if (c.if_compute_pressure_load_on_side(s)) {
                 
-                c.fe = &_fe_side_data->fe_derivative();
-                _fe_side_data->reinit_for_side(c, s);
-                _fe_side_var->init(c, sol_v);
+                c.fe = &_sol_fe_side_data->fe_derivative();
+                _sol_fe_side_data->reinit_for_side(c, s);
+                _sol_fe_side_var->init(c, sol_v);
                 _p_load->compute(c, res, jac);
             }
     }
@@ -423,9 +441,11 @@ public:
                            typename TraitsType::element_vector_t &res,
                            typename TraitsType::element_matrix_t *jac) {
         
-        c.fe = &_fe_data->fe_derivative();
-        _fe_data->reinit(c);
-        _fe_var->init(c, sol_v);
+        c.fe = &_sol_fe_data->fe_derivative();
+        _sol_fe_data->reinit(c);
+        _sol_fe_var->init(c, sol_v);
+        _density_fe_basis->reinit(*c.elem, _sol_fe_data->quadrature());
+        _density_fe_deriv->reinit(c);
         _density_fe_var->init(c, density_v);
         _density_sens_fe_var->init(c, density_sens);
 
@@ -449,9 +469,11 @@ public:
         // pressure load is independent of design parameters but thermoelastic load
         // depends on it. So, we compute the partial derivative of compliance contribution
         // from that term
-        c.fe = &_fe_data->fe_derivative();
-        _fe_data->reinit(c);
-        _fe_var->init(c, sol_v);
+        c.fe = &_sol_fe_data->fe_derivative();
+        _sol_fe_data->reinit(c);
+        _sol_fe_var->init(c, sol_v);
+        _density_fe_basis->reinit(*c.elem, _sol_fe_data->quadrature());
+        _density_fe_deriv->reinit(c);
         _density_fe_var->init(c, density_v);
         _density_sens_fe_var->init(c, density_sens);
 
@@ -477,13 +499,17 @@ public:
 private:
     
     // variables for quadrature and shape function
-    typename TraitsType::fe_data_t         *_fe_data;
-    typename TraitsType::fe_side_data_t    *_fe_side_data;
-    typename TraitsType::fe_var_t          *_fe_var;
-    typename TraitsType::fe_var_t          *_fe_side_var;
+    typename TraitsType::fe_data_t         *_sol_fe_data;
+    typename TraitsType::fe_side_data_t    *_sol_fe_side_data;
+    typename TraitsType::fe_var_t          *_sol_fe_var;
+    typename TraitsType::fe_var_t          *_sol_fe_side_var;
+
+    typename TraitsType::fe_basis_t        *_density_fe_basis;
+    typename TraitsType::fe_shape_t        *_density_fe_deriv;
     typename TraitsType::density_fe_var_t  *_density_fe_var;
     typename TraitsType::density_fe_var_t  *_density_sens_fe_var;
     typename TraitsType::density_field_t   *_density_field;
+
     typename TraitsType::prop_t            *_prop;
     typename TraitsType::energy_t          *_energy;
     typename TraitsType::temp_load_t       *_temp_load;

--- a/examples/structural/example_7/example_7.cpp
+++ b/examples/structural/example_7/example_7.cpp
@@ -268,24 +268,25 @@ public:
     using matrix_t  = Eigen::Matrix<scalar_t, Eigen::Dynamic, Eigen::Dynamic>;
     
     ElemOps(context_t  &c):
-    heaviside       (nullptr),
-    density         (nullptr),
-    E               (nullptr),
-    dt              (nullptr),
-    nu              (nullptr),
-    alpha           (nullptr),
-    press           (nullptr),
-    area            (nullptr),
-    _fe_data        (nullptr),
-    _fe_side_data   (nullptr),
-    _fe_var         (nullptr),
-    _fe_side_var    (nullptr),
-    _density_fe_var (nullptr),
-    _density_field  (nullptr),
-    _prop           (nullptr),
-    _energy         (nullptr),
-    _temp_load      (nullptr),
-    _p_load         (nullptr) {
+    heaviside            (nullptr),
+    density              (nullptr),
+    E                    (nullptr),
+    dt                   (nullptr),
+    nu                   (nullptr),
+    alpha                (nullptr),
+    press                (nullptr),
+    area                 (nullptr),
+    _fe_data             (nullptr),
+    _fe_side_data        (nullptr),
+    _fe_var              (nullptr),
+    _fe_side_var         (nullptr),
+    _density_fe_var      (nullptr),
+    _density_sens_fe_var (nullptr),
+    _density_field       (nullptr),
+    _prop                (nullptr),
+    _energy              (nullptr),
+    _temp_load           (nullptr),
+    _p_load              (nullptr) {
         
         _fe_data       = new typename TraitsType::fe_data_t;
         _fe_data->init(c.ex_init.q_order,
@@ -381,6 +382,8 @@ public:
 
         delete _density_field;
         delete _density_fe_var;
+        delete _density_sens_fe_var;
+
         
         delete _fe_var;
         delete _fe_side_var;

--- a/include/mast/base/exceptions.hpp
+++ b/include/mast/base/exceptions.hpp
@@ -49,6 +49,7 @@ public:
         << "Condition Violated: "
         << _cond << std::endl
         << _val_msg << std::endl
+        << _msg << std::endl
         << _file << " : " << _line << std::endl;
         
         throw 1;

--- a/include/mast/fe/eval/fe_basis_derivatives.hpp
+++ b/include/mast/fe/eval/fe_basis_derivatives.hpp
@@ -121,9 +121,6 @@ public:
         
         // for this class the number of basis functions should be equal to the number
         // of nodes
-        Assert2(c.n_nodes() == _fe_basis->n_basis(),
-                c.n_nodes(), _fe_basis->n_basis(),
-                "Number of shape functions assumed equal to number of nodes");
         Assert2(c.elem_dim() == ElemDim,
                 c.elem_dim(), ElemDim,
                 "Incorrect dimension of element.");
@@ -163,9 +160,6 @@ public:
         
         // for this class the number of basis functions should be equal to the number
         // of nodes
-        Assert2(c.n_nodes() == _fe_basis->n_basis(),
-                c.n_nodes(), _fe_basis->n_basis(),
-                "Number of shape functions assumed equal to number of nodes");
         Assert2(c.elem_dim() == ElemDim,
                 c.elem_dim(), ElemDim,
                 "Incorrect dimension of element.");

--- a/include/mast/mesh/generation/bracket2d.hpp
+++ b/include/mast/mesh/generation/bracket2d.hpp
@@ -327,7 +327,7 @@ struct Bracket2D {
         // if high order FE is used, libMesh requires atleast a second order
         // geometric element.
         //
-        if (c.fe_order > 1 && e_type == libMesh::QUAD4)
+        if (c.sol_fe_order > 1 && e_type == libMesh::QUAD4)
             e_type = libMesh::QUAD9;
         
         //
@@ -512,10 +512,13 @@ struct Bracket2D {
         //
         // this assumes that density variable has a constant value per element
         //
-        Assert2(c.fe_family == libMesh::LAGRANGE,
-                c.fe_family, libMesh::LAGRANGE,
+        Assert2(c.rho_fe_family == libMesh::LAGRANGE,
+                c.rho_fe_family, libMesh::LAGRANGE,
                 "Method assumes Lagrange interpolation function for density");
-        
+        Assert2(c.rho_fe_order == libMesh::FIRST,
+                c.rho_fe_order, libMesh::FIRST,
+                "Method assumes Lagrange interpolation function for density");
+
         real_t
         tol           = 1.e-12,
         length        = c.input("length", "length of domain along x-axis", 0.3),
@@ -543,7 +546,12 @@ struct Bracket2D {
             
             const libMesh::Elem* e = *e_it;
             
-            for (uint_t i=0; i<e->n_nodes(); i++) {
+            Assert0(e->type() == libMesh::QUAD4 ||
+                    e->type() == libMesh::QUAD9,
+                    "Method requires Quad4/Quad9 element");
+            
+            // only the first four nodes of the quad element are used
+            for (uint_t i=0; i<4; i++) {
                 
                 const libMesh::Node& n = *e->node_ptr(i);
                 

--- a/include/mast/mesh/generation/bracket3d.hpp
+++ b/include/mast/mesh/generation/bracket3d.hpp
@@ -382,9 +382,9 @@ struct Bracket3D {
         // if high order FE is used, libMesh requires atleast a second order
         // geometric element.
         //
-        if (c.fe_order > 1 && e_type == libMesh::HEX8)
+        if (c.sol_fe_order > 1 && e_type == libMesh::HEX8)
             e_type = libMesh::HEX27;
-        else if (c.fe_order > 1 && e_type == libMesh::TET4)
+        else if (c.sol_fe_order > 1 && e_type == libMesh::TET4)
             e_type = libMesh::TET10;
         
         //
@@ -444,10 +444,13 @@ struct Bracket3D {
         //
         // this assumes that density variable has a constant value per element
         //
-        Assert2(c.fe_family == libMesh::LAGRANGE,
-                c.fe_family, libMesh::LAGRANGE,
+        Assert2(c.rho_fe_family == libMesh::LAGRANGE,
+                c.rho_fe_family, libMesh::LAGRANGE,
                 "Method assumes Lagrange interpolation function for density");
-        
+        Assert2(c.rho_fe_order == libMesh::FIRST,
+                c.rho_fe_order, libMesh::FIRST,
+                "Method assumes Lagrange interpolation function for density");
+
         real_t
         tol           = 1.e-12,
         rho_min       = c.input("rho_min", "lower limit on density variable", 0.),
@@ -472,7 +475,12 @@ struct Bracket3D {
             
             const libMesh::Elem* e = *e_it;
             
-            for (uint_t i=0; i<e->n_nodes(); i++) {
+            Assert0(e->type() == libMesh::HEX8 ||
+                    e->type() == libMesh::HEX27,
+                    "Method requires Hex8/Hex27 element");
+            
+            // only the first eight nodes of the hex element are used
+            for (uint_t i=0; i<8; i++) {
 
                 const libMesh::Node& n = *e->node_ptr(i);
                 

--- a/include/mast/mesh/generation/inplane2d.hpp
+++ b/include/mast/mesh/generation/inplane2d.hpp
@@ -308,7 +308,7 @@ struct Inplane2D {
         // if high order FE is used, libMesh requires atleast a second order
         // geometric element.
         //
-        if (c.fe_order > 1 && e_type == libMesh::QUAD4)
+        if (c.sol_fe_order > 1 && e_type == libMesh::QUAD4)
             e_type = libMesh::QUAD9;
         
         //
@@ -362,10 +362,13 @@ struct Inplane2D {
         //
         // this assumes that density variable has a constant value per element
         //
-        Assert2(c.fe_family == libMesh::LAGRANGE,
-                c.fe_family, libMesh::LAGRANGE,
+        Assert2(c.rho_fe_family == libMesh::LAGRANGE,
+                c.rho_fe_family, libMesh::LAGRANGE,
                 "Method assumes Lagrange interpolation function for density");
-        
+        Assert2(c.rho_fe_order == libMesh::FIRST,
+                c.rho_fe_order, libMesh::FIRST,
+                "Method assumes Lagrange interpolation function for density");
+
         real_t
         tol           = 1.e-12,
         length        = c.input("length", "length of domain along x-axis", 1.0),
@@ -393,7 +396,12 @@ struct Inplane2D {
             
             const libMesh::Elem* e = *e_it;
             
-            for (uint_t i=0; i<e->n_nodes(); i++) {
+            Assert0(e->type() == libMesh::QUAD4 ||
+                    e->type() == libMesh::QUAD9,
+                    "Method requires Quad4/Quad9 element");
+            
+            // only the first four nodes of the quad element are used
+            for (uint_t i=0; i<4; i++) {
                 
                 const libMesh::Node& n = *e->node_ptr(i);
                 

--- a/include/mast/mesh/generation/panel2d.hpp
+++ b/include/mast/mesh/generation/panel2d.hpp
@@ -322,7 +322,7 @@ struct Panel2D {
         // if high order FE is used, libMesh requires atleast a second order
         // geometric element.
         //
-        if (c.fe_order > 1 && e_type == libMesh::QUAD4)
+        if (c.sol_fe_order > 1 && e_type == libMesh::QUAD4)
             e_type = libMesh::QUAD9;
         
         //
@@ -375,10 +375,13 @@ struct Panel2D {
         //
         // this assumes that density variable has a constant value per element
         //
-        Assert2(c.fe_family == libMesh::LAGRANGE,
-                c.fe_family, libMesh::LAGRANGE,
+        Assert2(c.rho_fe_family == libMesh::LAGRANGE,
+                c.rho_fe_family, libMesh::LAGRANGE,
                 "Method assumes Lagrange interpolation function for density");
-        
+        Assert2(c.rho_fe_order == libMesh::FIRST,
+                c.rho_fe_order, libMesh::FIRST,
+                "Method assumes Lagrange interpolation function for density");
+
         real_t
         vf            = c.input("volume_fraction", "upper limit for the volume fraction", 0.2);
         
@@ -401,7 +404,12 @@ struct Panel2D {
             
             const libMesh::Elem* e = *e_it;
             
-            for (uint_t i=0; i<e->n_nodes(); i++) {
+            Assert0(e->type() == libMesh::QUAD4 ||
+                    e->type() == libMesh::QUAD9,
+                    "Method requires Quad4/Quad9 element");
+            
+            // only the first four nodes of the quad element are used
+            for (uint_t i=0; i<4; i++) {
                 
                 const libMesh::Node& n = *e->node_ptr(i);
                 

--- a/include/mast/mesh/generation/panel3d.hpp
+++ b/include/mast/mesh/generation/panel3d.hpp
@@ -399,9 +399,9 @@ struct Panel3D {
         // if high order FE is used, libMesh requires atleast a second order
         // geometric element.
         //
-        if (c.fe_order > 1 && e_type == libMesh::HEX8)
+        if (c.sol_fe_order > 1 && e_type == libMesh::HEX8)
             e_type = libMesh::HEX27;
-        else if (c.fe_order > 1 && e_type == libMesh::TET4)
+        else if (c.rho_fe_order > 1 && e_type == libMesh::TET4)
             e_type = libMesh::TET10;
         
         //
@@ -462,10 +462,13 @@ struct Panel3D {
         //
         // this assumes that density variable has a constant value per element
         //
-        Assert2(c.fe_family == libMesh::LAGRANGE,
-                c.fe_family, libMesh::LAGRANGE,
+        Assert2(c.rho_fe_family == libMesh::LAGRANGE,
+                c.rho_fe_family, libMesh::LAGRANGE,
                 "Method assumes Lagrange interpolation function for density");
-        
+        Assert2(c.rho_fe_order == libMesh::FIRST,
+                c.rho_fe_order, libMesh::FIRST,
+                "Method assumes Lagrange interpolation function for density");
+
         real_t
         vf            = c.input("volume_fraction", "upper limit for the volume fraction", 0.2);
         
@@ -488,7 +491,12 @@ struct Panel3D {
             
             const libMesh::Elem* e = *e_it;
             
-            for (uint_t i=0; i<e->n_nodes(); i++) {
+            Assert0(e->type() == libMesh::HEX8 ||
+                    e->type() == libMesh::HEX27,
+                    "Method requires Hex8/Hex27 element");
+            
+            // only the first eight nodes of the hex element are used
+            for (uint_t i=0; i<8; i++) {
 
                 const libMesh::Node& n = *e->node_ptr(i);
                 

--- a/include/mast/mesh/generation/truss2d.hpp
+++ b/include/mast/mesh/generation/truss2d.hpp
@@ -328,7 +328,7 @@ struct Truss2D {
         // if high order FE is used, libMesh requires atleast a second order
         // geometric element.
         //
-        if (c.fe_order > 1 && e_type == libMesh::QUAD4)
+        if (c.sol_fe_order > 1 && e_type == libMesh::QUAD4)
             e_type = libMesh::QUAD9;
         
         //
@@ -381,10 +381,13 @@ struct Truss2D {
         //
         // this assumes that density variable has a constant value per element
         //
-        Assert2(c.fe_family == libMesh::LAGRANGE,
-                c.fe_family, libMesh::LAGRANGE,
+        Assert2(c.rho_fe_family == libMesh::LAGRANGE,
+                c.rho_fe_family, libMesh::LAGRANGE,
                 "Method assumes Lagrange interpolation function for density");
-        
+        Assert2(c.rho_fe_order == libMesh::FIRST,
+                c.rho_fe_order, libMesh::FIRST,
+                "Method assumes Lagrange interpolation function for density");
+
         real_t
         tol           = 1.e-12,
         length        = c.input("length", "length of domain along x-axis", 0.24),
@@ -412,7 +415,12 @@ struct Truss2D {
             
             const libMesh::Elem* e = *e_it;
             
-            for (uint_t i=0; i<e->n_nodes(); i++) {
+            Assert0(e->type() == libMesh::QUAD4 ||
+                    e->type() == libMesh::QUAD9,
+                    "Method requires Quad4/Quad9 element");
+            
+            // only the first four nodes of the quad element are used
+            for (uint_t i=0; i<4; i++) {
                 
                 const libMesh::Node& n = *e->node_ptr(i);
                 

--- a/include/mast/mesh/generation/truss3d.hpp
+++ b/include/mast/mesh/generation/truss3d.hpp
@@ -382,9 +382,9 @@ struct Truss3D {
         // if high order FE is used, libMesh requires atleast a second order
         // geometric element.
         //
-        if (c.fe_order > 1 && e_type == libMesh::HEX8)
+        if (c.sol_fe_order > 1 && e_type == libMesh::HEX8)
             e_type = libMesh::HEX27;
-        else if (c.fe_order > 1 && e_type == libMesh::TET4)
+        else if (c.sol_fe_order > 1 && e_type == libMesh::TET4)
             e_type = libMesh::TET10;
         
         //
@@ -445,10 +445,13 @@ struct Truss3D {
         //
         // this assumes that density variable has a constant value per element
         //
-        Assert2(c.fe_family == libMesh::LAGRANGE,
-                c.fe_family, libMesh::LAGRANGE,
+        Assert2(c.rho_fe_family == libMesh::LAGRANGE,
+                c.rho_fe_family, libMesh::LAGRANGE,
                 "Method assumes Lagrange interpolation function for density");
-        
+        Assert2(c.rho_fe_order == libMesh::FIRST,
+                c.rho_fe_order, libMesh::FIRST,
+                "Method assumes Lagrange interpolation function for density");
+
         real_t
         tol           = 1.e-12,
         length        = c.input("length", "length of domain along x-axis", 0.24),
@@ -476,7 +479,12 @@ struct Truss3D {
             
             const libMesh::Elem* e = *e_it;
             
-            for (uint_t i=0; i<e->n_nodes(); i++) {
+            Assert0(e->type() == libMesh::HEX8 ||
+                    e->type() == libMesh::HEX27,
+                    "Method requires Hex8/Hex27 element");
+            
+            // only the first eight nodes of the hex element are used
+            for (uint_t i=0; i<8; i++) {
 
                 const libMesh::Node& n = *e->node_ptr(i);
                 

--- a/include/mast/mesh/libmesh/geometric_filter.hpp
+++ b/include/mast/mesh/libmesh/geometric_filter.hpp
@@ -28,6 +28,7 @@
 #include <mast/numerics/utility.hpp>
 #include <mast/optimization/design_parameter_vector.hpp>
 #include <mast/mesh/libmesh/geometric_filter_augment_send_list.hpp>
+#include <mast/mesh/libmesh/utility.hpp>
 
 // libMesh includes
 #include "libmesh/system.h"
@@ -977,7 +978,7 @@ private:
             const libMesh::Elem *e = *it;
             elem_h = e->hmax();
             
-            for (uint_t i=0; i<_n_nodes_on_elem(*e); i++) {
+            for (uint_t i=0; i<MAST::Mesh::libMeshWrapper::Utility::n_linear_basis_nodes_on_elem(*e); i++) {
                 
                 const libMesh::Node* nd = e->node_ptr(i);
                 dof_num = nd->dof_number(sys_num, 0, 0);
@@ -1102,27 +1103,6 @@ private:
         CHKERRABORT(_system.comm().get(), ierr);
     }
     
-    
-    /*!
-     * identifies number of ndoes on element
-     */
-    inline uint_t _n_nodes_on_elem(const libMesh::Elem& e) const {
-        
-        switch (e.type()) {
-            case libMesh::QUAD4:
-            case libMesh::QUAD9:
-                return 4;
-                break;
-                
-            case libMesh::HEX8:
-            case libMesh::HEX27:
-                return 8;
-                break;
-                
-            default:
-                Error(false, "Elem type must be QUAD4/QUAD9 for 2D or HEX8/HEX27 for 3D");
-        }
-    }
     
     /*!
      *   system on which the level set discrete function is defined

--- a/include/mast/mesh/libmesh/geometric_filter.hpp
+++ b/include/mast/mesh/libmesh/geometric_filter.hpp
@@ -295,23 +295,13 @@ private:
         uint_t                      _n_nodes;
 
     public:
-        NanoflannMeshAdaptor (const libMesh::MeshBase & mesh) :
-        _mesh           (mesh),
-        _n_local_nodes  (mesh.n_local_nodes()),
-        _n_nodes        (mesh.n_nodes()) {
-            
-            nodes.reserve(_n_local_nodes);
-            
-            libMesh::MeshBase::const_node_iterator
-            it   = mesh.local_nodes_begin(),
-            end  = mesh.local_nodes_end();
-            
-            for ( ; it != end; it++) {
-                
-                nodes.push_back(*it);
-                node_id_to_vec_index[(*it)->id()] = nodes.size()-1;
-            }
-        }
+        NanoflannMeshAdaptor (const libMesh::MeshBase                 &mesh,
+                              const std::vector<const libMesh::Node*> &nodes) :
+        _mesh                 (mesh),
+        _n_local_nodes        (nodes.size()),
+        _n_nodes              (mesh.n_nodes()),
+        _nodes                (nodes)
+        { }
         
         /**
          * libMesh \p Point coordinate type
@@ -362,7 +352,7 @@ private:
                     "Invalid node index");
             Assert1(dim < 3, dim, "Invalid dimension");
 
-            return (*nodes[idx])(dim);
+            return (*_nodes[idx])(dim);
         }
         
         /**
@@ -374,8 +364,7 @@ private:
         template <class BBOX>
         inline bool kdtree_get_bbox(BBOX & /* bb */) const { return false; }
         
-        std::vector<libMesh::Node*> nodes;
-        std::map<uint_t, uint_t>    node_id_to_vec_index;
+        const std::vector<const libMesh::Node*>  &_nodes;
     };
     
     // Declare a type templated on NanoflannMeshAdaptor
@@ -409,7 +398,7 @@ private:
         // contrib/nanoflann/examples/pointcloud_adaptor_example.cpp
         
         // Build adaptor and tree objects
-        NanoflannMeshAdaptor<3> mesh_adaptor(mesh);
+        NanoflannMeshAdaptor<3> mesh_adaptor(mesh, _nodes);
         kd_tree_t kd_tree(3, mesh_adaptor, nanoflann::KDTreeSingleIndexAdaptorParams(/*max leaf=*/10));
         
         // Construct the tree
@@ -466,9 +455,9 @@ private:
         std::map<const libMesh::Node*, real_t>
         node_sum;
                 
-        libMesh::MeshBase::const_node_iterator
-        node_it      =  mesh.local_nodes_begin(),
-        node_end     =  mesh.local_nodes_end();
+        std::vector<const libMesh::Node*>::const_iterator
+        node_it      =  _nodes.begin(),
+        node_end     =  _nodes.end();
         
         std::vector<std::vector<const libMesh::Node*>>
         remote_node_dependency(size);
@@ -600,7 +589,7 @@ private:
                 
                 for (unsigned r=0; r<indices_dists.size(); ++r) {
                     
-                    const libMesh::Node* nd = mesh_adaptor.nodes[indices_dists[r].first];
+                    const libMesh::Node* nd = _nodes[indices_dists[r].first];
                     
                     // location of the node
                     filter_data_node_loc_send[i].push_back((*nd)(0));
@@ -648,7 +637,7 @@ private:
         // For every node in the mesh, search the KDtree and find any
         // nodes at _radius distance from the current
         // node being searched... this will be added to the .
-        node_it      =  mesh.local_nodes_begin();
+        node_it      =  _nodes.begin();
             
         for (; node_it != node_end; node_it++) {
             
@@ -665,7 +654,7 @@ private:
                 std::vector<std::pair<size_t, real_t>>
                 indices_dists;
                 indices_dists.push_back(std::pair<size_t, real_t>
-                                        (mesh_adaptor.node_id_to_vec_index[node->id()], 0.));
+                                        (_node_id_to_vec_index[node->id()], 0.));
                 nanoflann::RadiusResultSet<real_t, size_t>
                 resultSet(nd_radius*nd_radius, indices_dists);
                 
@@ -683,7 +672,7 @@ private:
                             "Node distance must be <= search radius");
                     
                     sum  += nd_radius - d_12;
-                    dof_2 = mesh_adaptor.nodes[indices_dists[r].first]->dof_number(_system.number(), 0, 0);
+                    dof_2 = _nodes[indices_dists[r].first]->dof_number(_system.number(), 0, 0);
                     
                     _filter_map[dof_1].push_back(std::pair<uint_t, real_t>
                                                 (dof_2, nd_radius - d_12));
@@ -763,7 +752,7 @@ private:
         // now normalize the weights with respect to the sum
         // with the coefficients computed for dof_1, divide each coefficient
         // with the sum
-        node_it      =  mesh.local_nodes_begin();
+        node_it      =  _nodes.begin();
             
         for (; node_it != node_end; node_it++) {
             
@@ -973,6 +962,12 @@ private:
         sys_num         = _system.number(),
         dof_num         = 0;
         
+
+        _nodes.clear();
+        _nodes.reserve(_system.get_mesh().n_local_nodes());
+        
+        std::set<const libMesh::Node*>
+        all_local_nodes;
         
         real_t
         elem_h = 0.;
@@ -982,12 +977,18 @@ private:
             const libMesh::Elem *e = *it;
             elem_h = e->hmax();
             
-            for (uint_t i=0; i<e->n_nodes(); i++) {
+            for (uint_t i=0; i<_n_nodes_on_elem(*e); i++) {
                 
-                dof_num = e->node_ptr(i)->dof_number(sys_num, 0, 0);
+                const libMesh::Node* nd = e->node_ptr(i);
+                dof_num = nd->dof_number(sys_num, 0, 0);
                 
                 _radius->add(dof_num, elem_h);
                 n_elem_sum->add(dof_num, 1.);
+
+                // if the node is a local node, add it to the set
+                if (dof_num >= first_local_dof &&
+                    dof_num <  last_local_dof)
+                    all_local_nodes.insert(nd);
             }
         }
         
@@ -999,6 +1000,16 @@ private:
             _radius->set(i, _radius->el(i)/n_elem_sum->el(i));
         }
         _radius->close();
+        
+        // initialize the local nodes
+        std::set<const libMesh::Node*>::const_iterator
+        n_it  = all_local_nodes.begin(),
+        n_end = all_local_nodes.end();
+        
+        for ( ; n_it != n_end; n_it++) {
+            _nodes.push_back(*n_it);
+            _node_id_to_vec_index[(*n_it)->id()] = _nodes.size()-1;
+        }
     }
     
     
@@ -1093,6 +1104,27 @@ private:
     
     
     /*!
+     * identifies number of ndoes on element
+     */
+    inline uint_t _n_nodes_on_elem(const libMesh::Elem& e) const {
+        
+        switch (e.type()) {
+            case libMesh::QUAD4:
+            case libMesh::QUAD9:
+                return 4;
+                break;
+                
+            case libMesh::HEX8:
+            case libMesh::HEX27:
+                return 8;
+                break;
+                
+            default:
+                Error(false, "Elem type must be QUAD4/QUAD9 for 2D or HEX8/HEX27 for 3D");
+        }
+    }
+    
+    /*!
      *   system on which the level set discrete function is defined
      */
     libMesh::System& _system;
@@ -1130,6 +1162,17 @@ private:
      */
     std::vector<uint_t> _forward_send_list;
     
+    /*!
+     *   Local nodes that belong to the first-order Lagrange basis on the elements
+     */
+    std::vector<const libMesh::Node*> _nodes;
+
+    
+    /*!
+     *   id of local nodes for use in kd-tree search
+     */
+    std::map<uint_t, uint_t>          _node_id_to_vec_index;
+
     /*!
      * Sparse Matrix object that stores the filtering matrix. This is used for both both forward and reverse operations
      */

--- a/include/mast/mesh/libmesh/utility.hpp
+++ b/include/mast/mesh/libmesh/utility.hpp
@@ -1,0 +1,64 @@
+/*
+* MAST: Multidisciplinary-design Adaptation and Sensitivity Toolkit
+* Copyright (C) 2013-2020  Manav Bhatia and MAST authors
+*
+* This library is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* This library is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this library; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef __mast_mesh_libmesh_utility_h__
+#define __mast_mesh_libmesh_utility_h__
+
+// MAST includes
+#include <mast/base/mast_data_types.h>
+
+// libMesh includes
+#include <libmesh/elem.h>
+#include <libmesh/enum_elem_type.h>
+
+namespace MAST {
+namespace Mesh {
+namespace libMeshWrapper {
+namespace Utility {
+
+
+/*!
+ * identifies number of ndoes on element
+ */
+inline uint_t n_linear_basis_nodes_on_elem(const libMesh::Elem& e) {
+    
+    switch (e.type()) {
+        case libMesh::QUAD4:
+        case libMesh::QUAD9:
+            return 4;
+            break;
+            
+        case libMesh::HEX8:
+        case libMesh::HEX27:
+            return 8;
+            break;
+            
+        default:
+            Error(false, "Elem type must be QUAD4/QUAD9 for 2D or HEX8/HEX27 for 3D");
+    }
+}
+
+
+
+} // namespace Utility
+} // namespace libMesh
+} // namespace Mesh
+} // namespace MAST
+
+#endif // __mast_mesh_libmesh_utility_h__

--- a/include/mast/optimization/topology/simp/libmesh/assemble_output_sensitivity.hpp
+++ b/include/mast/optimization/topology/simp/libmesh/assemble_output_sensitivity.hpp
@@ -27,6 +27,7 @@
 #include <mast/base/assembly/libmesh/accessor.hpp>
 #include <mast/numerics/utility.hpp>
 #include <mast/optimization/design_parameter_vector.hpp>
+#include <mast/mesh/libmesh/utility.hpp>
 
 // libMesh includes
 #include <libmesh/nonlinear_implicit_system.h>
@@ -92,8 +93,9 @@ public:
                 dvs.size(), sens.size(),
                 "DV and sensitivity vectors must have same size");
            
-        const uint_t
-        n_density_dofs = c.rho_sys->n_dofs();
+        uint_t
+        n_density_dofs = c.rho_sys->n_dofs(),
+        n_nodes        = 0;
 
         MAST::Numerics::Utility::setZero(sens);
 
@@ -139,7 +141,9 @@ public:
             const std::vector<libMesh::dof_id_type>
             &density_dof_ids = density_accessor.dof_indices();
 
-            for (uint_t i=0; i<c.elem->n_nodes(); i++) {
+            n_nodes = MAST::Mesh::libMeshWrapper::Utility::n_linear_basis_nodes_on_elem(**el);
+            
+            for (uint_t i=0; i<n_nodes; i++) {
                 
                 if (!dvs.is_design_parameter_dof_id(density_dof_ids[i]))
                     continue;


### PR DESCRIPTION
This PR enables:
* Use of first order interpolation for density interpolation and high-order interpolation for analysis mesh.
* Refactoring in geometric filter to use only the first 4/8 nodes in Quad/Hex elements
* Necessary fixes in the remaining code support this.