### PR TITLE
Adding rigid-body rotation to null-space definition

### DIFF
--- a/examples/structural/example_6/example_6.cpp
+++ b/examples/structural/example_6/example_6.cpp
@@ -129,7 +129,7 @@ public:
 
         // create and attach the null space to the matrix
         MAST::Physics::Elasticity::libMeshWrapper::NullSpace
-        null_sp(*sys, ModelType::dim, false);
+        null_sp(*sys, ModelType::dim, true);
         
         Mat m = dynamic_cast<libMesh::PetscMatrix<real_t>*>(sys->matrix)->mat();
         null_sp.attach_to_matrix(m);

--- a/examples/structural/example_7/example_7.cpp
+++ b/examples/structural/example_7/example_7.cpp
@@ -148,7 +148,7 @@ public:
 
         // create and attach the null space to the matrix
         MAST::Physics::Elasticity::libMeshWrapper::NullSpace
-        null_sp(*sys, ModelType::dim, false);
+        null_sp(*sys, ModelType::dim, true);
         
         Mat m = dynamic_cast<libMesh::PetscMatrix<real_t>*>(sys->matrix)->mat();
         null_sp.attach_to_matrix(m);


### PR DESCRIPTION
rigid-body rotation modes are also included in the creation of null-space operator.